### PR TITLE
Grammar check on multiple chapters and clean unnecesary CRs

### DIFF
--- a/Chapters/Collections/Collections.pillar
+++ b/Chapters/Collections/Collections.pillar
@@ -1,48 +1,26 @@
 !! Collections 
 @cha:collections
 
-To make good use of the collection classes, the reader needs at least a
-superficial knowledge of the wide variety of collections that exist, and their commonalities and differences.
-This is what this chapter is about.
+To make good use of the collection classes, the reader needs at least a superficial knowledge of the wide variety of collections that exist, and their commonalities and differences. This is what this chapter is about.
 
-The collection classes form a loosely-defined group of general-purpose
-subclasses of ==Collection== and ==Stream==. Some of these subclasses such as ==Bitmap==,
-or ==CompiledMethod== are special-purpose classes crafted for
-use in other parts of the system or in applications, and hence not categorized
-as ''Collections'' by the system organization. 
+The collection classes form a loosely-defined group of general-purpose subclasses of ==Collection== and ==Stream==. Some of these subclasses such as ==Bitmap==,  or ==CompiledMethod== are special-purpose classes crafted for use in other parts of the system or in applications, and hence not categorized as ''Collections'' by the system organization. 
 
-In this chapter, we use the term ''Collection Hierarchy'' to mean ==Collection== and its
-subclasses that are ''also'' in the packages labelled ==Collections-*==. We use
-the term ''Stream Hierarchy'' to mean ==Stream== and its subclasses that are
-''also'' in the ==Collections-Streams== packages.
+In this chapter, we use the term ''Collection Hierarchy'' to mean ==Collection== and its subclasses that are ''also'' in the packages labelled ==Collections-*==. We use the term ''Stream Hierarchy'' to mean ==Stream== and its subclasses that are ''also'' in the ==Collections-Streams== packages.
 
-In this chapter we focus mainly on the subset of collection classes shown in
-Figure *@fig:CollClassesTree*. Streams will be discussed separately in
-Chapter *: Streams>../Streams/Streams.pillar@cha:streams*.
+In this chapter we focus mainly on the subset of collection classes shown in Figure *@fig:CollClassesTree*. Streams will be discussed separately in Chapter *: Streams>../Streams/Streams.pillar@cha:streams*.
 
-Pharo by default provide a good set of collections. 
-In addition, the project "Containers" available at *http://www.github.com/Pharo-Containers/* proposes alternate implementations or new collections and data structures. 
+Pharo by default provide a good set of collections. In addition, the project "Containers" available at *http://www.github.com/Pharo-Containers/* proposes alternate implementations or new collections and data structures. 
 
 +Some of the key collection classes in Pharo.>file://figures/CollectionHierarchy.png|label=fig:CollClassesTree+
 
-Let us start with an important point about the design of the collections in Pharo. 
-Their APIs heavily use high-order functions: so while we can use for loops like in old Java, most of the time Pharo developers will use iterator style based on high-order functions.
+Let us start with an important point about the design of the collections in Pharo. Their APIs heavily use high-order functions: so while we can use for loops like in old Java, most of the time Pharo developers will use iterator style based on high-order functions.
 
 !!!High-order functions
 @sec:varieties
 
-Programming with collections using high-order functions rather than individual
-elements is an important way to raise the level of abstraction of a program. The
-Lisp function ==map==, which applies an argument function to every element of a
-list and returns a new list containing the results is an early example of this
-style. Following its Smalltalk root, Pharo adopts this collection-based
-high-order programming as a central tenet. Modern functional programming
-languages such as ML and Haskell have followed Smalltalk's lead.
+Programming with collections using high-order functions rather than individual elements is an important way to raise the level of abstraction of a program. The Lisp function ==map==, which applies an argument function to every element of a list and returns a new list containing the results is an early example of this style. Following its Smalltalk root, Pharo adopts this collection-based high-order programming as a central tenet. Modern functional programming languages such as ML and Haskell have followed Smalltalk's lead.
 
-Why is this a good idea? Let us suppose you have a data structure containing a
-collection of student records, and wish to perform some action on all of the
-students that meet some criteria. Programmers raised to use an imperative
-language will immediately reach for a loop, but the Pharo programmer will
+Why is this a good idea? Let us suppose you have a data structure containing a collection of student records, and wish to perform some action on all of the students that meet some criteria. Programmers raised to use an imperative language will immediately reach for a loop, but the Pharo programmer will
 write:
 
 [[[
@@ -50,31 +28,15 @@ students
 	select: [ :each | each gpa < threshold ]
 ]]]
 
-This expression returns a new collection containing precisely those elements of
-==students== for which the block (the bracketed function) returns ==true==. The
-block can be thought of as a lambda-expression defining an anonymous function
-==x. x gpa < threshold==. This code has the simplicity and elegance of a
+This expression returns a new collection containing precisely those elements of ==students== for which the block (the bracketed function) returns ==true==. The block can be thought of as a lambda-expression defining an anonymous function ==x. x gpa < threshold==. This code has the simplicity and elegance of a
 domain-specific query language.
 
-The message ==select:== is understood by ''all'' collections in Pharo.
-There is no need to find out if the student data structure is an array or a
-linked list: the ==select:== message is understood by both. Note that this is
-quite different from using a loop, where one must know whether ==students== is
-an array or a linked list before the loop can be set up.
+The message ==select:== is understood by ''all'' collections in Pharo. There is no need to find out if the student data structure is an array or a linked list: the ==select:== message is understood by both. Note that this it's quite different from using a loop, where one must know whether ==students== is an array or a linked list before the loop can be set up.
 
-In Pharo, when one speaks of a collection without being more specific about
-the kind of collection, one means an object that supports well-defined protocols
-for testing membership and enumerating the elements. ''All'' collections
-understand the ==testing== messages ==includes:==, ==isEmpty== and
-==occurrencesOf:==. ''All'' collections understand the ==enumeration== messages
-==do:==, ==select:==, ==reject:== (which is the opposite of ==select:==),
-==collect:== (which is like Lisp's ==map==), ==detect:ifNone:==,
-==inject:into:== (which performs a left fold) and many more. It is the ubiquity
+In Pharo, when one speaks of a collection without being more specific about the kind of collection, one means an object that supports well-defined protocols for testing membership and enumerating the elements. ''All'' collections understand the ==testing== messages ==includes:==, ==isEmpty== and ==occurrencesOf:==. ''All'' collections understand the ==enumeration== messages ==do:==, ==select:==, ==reject:== (which is the opposite of ==select:==), ==collect:== (which is like Lisp's ==map==), ==detect:ifNone:==, ==inject:into:== (which performs a left fold) and many more. It is the ubiquity
 of this protocol, as well as its variety, that makes it so powerful.
 
-The table below summarizes the standard protocols supported by most of
-the classes in the collection hierarchy. These methods are defined, redefined,
-optimized or occasionally even forbidden by subclasses of ==Collection==.
+The table below summarizes the standard protocols supported by most of the classes in the collection hierarchy. These methods are defined, redefined, optimized or occasionally even forbidden by subclasses of ==Collection==.
 
 |!Protocol |!Methods |
 | ==accessing== | ==size==, ==capacity==, ==at:==, ==at:put:== |
@@ -91,9 +53,7 @@ optimized or occasionally even forbidden by subclasses of ==Collection==.
 !!!The varieties of collections
 @sec:varieties
 
-Beyond this basic uniformity, there are many different kinds of collections
-either supporting different protocols or providing different behaviour for the
-same requests. Let us briefly observe some of the key differences:
+Beyond this basic uniformity, there are many different kinds of collections either supporting different protocols or providing different behaviour for the same requests. Let us briefly observe some of the key differences:
 
 ;==Sequenceable:==
 :Instances of all subclasses of ==SequenceableCollection== start from a ==first== element and proceed in a well-defined order to a ==last== element. Instances of ==Set==, ==Bag== and ==Dictionary==, on the other hand, are not sequenceable.
@@ -112,16 +72,13 @@ same requests. Let us briefly observe some of the key differences:
 ;==Heterogeneous:==
 :Most collections will hold any kind of element. A ==String==, ==CharacterArray== or ==Symbol==, however, only holds ==Character==s. An ==Array== will hold any mix of objects, but a ==ByteArray== only holds Bytes. A ==LinkedList== is constrained to hold elements that conform to the ==Link== ==accessing== protocol.
 
-
 !!!Collection implementations
 
 @sec:implementation
 
 +Some collection classes categorized by implementation technique.>file://figures/CollectionsByImpl.png|width=100|label=fig:collsByImpl+
 
-These categorizations by functionality are not our only concern; we must also
-consider how the collection classes are implemented. As shown in Figure
-*@fig:collsByImpl*, five main implementation techniques are employed.
+These categorizations by functionality are not our only concern; we must also consider how the collection classes are implemented. As shown in Figure *@fig:collsByImpl*, five main implementation techniques are employed.
 
 - Arrays store their elements in the (indexable) instance variables of the collection object itself; as a consequence, arrays must be of a fixed size, but can be created with a single memory allocation.
 - ==OrderedCollections== and ==SortedCollections== store their elements in an array that is referenced by one of the instance variables of the collection. Consequently, the internal array can be replaced with a larger one if the collection grows beyond its storage capacity.
@@ -129,29 +86,20 @@ consider how the collection classes are implemented. As shown in Figure
 -LinkedLists use a standard singly-linked representation.
 -Intervals are represented by three integers that record the two endpoints and the step size.
 
-In addition to these classes, there are also ''weak'' variants of ==Array==,
-==Set== and of the various kinds of dictionary. These collections hold onto
-their elements weakly, i.e., in a way that does not prevent the elements
-from being garbage collected. The Pharo virtual machine is aware of these
-classes and handles them specially.
-
+In addition to these classes, there are also ''weak'' variants of ==Array==, ==Set== and of the various kinds of dictionary. These collections hold onto  their elements weakly, i.e., in a way that does not prevent the elements from being garbage collected. The Pharo virtual machine is aware of these classes and handles them specially.
 
 !!!Examples of key classes
 
-We present now the most common or important collection classes using simple code
-examples. The main protocols of collections are:
+We present now the most common or important collection classes using simple code examples. The main protocols of collections are:
 
 - messages ==at:==, ==at:put:== — to access an element,
 - messages ==add:==, ==remove:== — to add or remove an element,
 - messages ==size==, ==isEmpty==, ==include:== — to get some information about the collection,
 - messages ==do:==, ==collect:==, ==select:== — to iterate over the collection.
 
-Each collection may implement (or not) such protocols, and when they do, they
-interpret them to fit with their semantics. We suggest you to browse the classes
-themselves in order to identify specific and more advanced protocols.
+Each collection may implement (or not) such protocols, and when they do, they interpret them to fit with their semantics. We suggest you to browse the classes themselves in order to identify specific and more advanced protocols.
 
-We will focus on the most common collection classes: ==OrderedCollection==,
-==Set==, ==SortedCollection==, ==Dictionary==, ==Interval==, and ==Array==.
+We will focus on the most common collection classes: ==OrderedCollection==, ==Set==, ==SortedCollection==, ==Dictionary==, ==Interval==, and ==Array==.
 
 
 !!!Common creation protocol
@@ -235,19 +183,13 @@ Bag withAll: #(7 3 1 3)
 >>> a Bag(7 1 3 3)
 ]]]
 
-
 !!!==Array==
 
-An ==Array== is a fixed-sized collection of elements accessed by integer
-indices. Contrary to the C convention in Pharo, the first element of an array is
-at position 1 and not 0. The main protocol to access array elements is the
-method ==at:== and ==at:put:==. 
+An ==Array== is a fixed-sized collection of elements accessed by integer indices. Contrary to the C convention in Pharo, the first element of an array is at position 1 and not 0. The main protocol to access array elements is the method ==at:== and ==at:put:==. 
 - ==at: anInteger== returns the element at index ==anInteger==. 
 - ==at: anInteger put: anObject== puts ==anObject== at index ==anInteger==. 
 
-Arrays are fixed-size collections therefore we cannot add or
-remove elements at the end of an array. The following code creates an array of
-size 5, puts values in the first 3 locations and returns the first element.
+Arrays are fixed-size collections therefore we cannot add or remove elements at the end of an array. The following code creates an array of size 5, puts values in the first 3 locations and returns the first element.
 
 [[[testcase=true
 | anArray |
@@ -273,51 +215,35 @@ new: 5== creates an array of size 5.
 
 !!!!Creation using ==with:==
 
-The ==with:*== messages allow one to specify the value of the elements. The
-following code creates an array of three elements consisting of the number
-==4==, the fraction ==3/2== and the string =='lulu'==.
+The ==with:*== messages allow one to specify the value of the elements. The following code creates an array of three elements consisting of the number ==4==, the fraction ==3/2== and the string =='lulu'==.
 
 [[[testcase=true
 Array with: 4 with: 3/2 with: 'lulu'
 >>>  {4. (3/2). 'lulu'}
 ]]]
 
-
 !!!!Literal creation with ==#()==
 
-The expression ==#()== creates literal arrays with constants or ''literal''
-elements that have to be known when the expression is compiled, and not when it
-is executed. The following code creates an array of size 2 where the first
-element is the (literal) number ==1== and the second the (literal) string
-=='here'==.
+The expression ==#()== creates literal arrays with constants or ''literal'' elements that have to be known when the expression is compiled, and not when it is executed. The following code creates an array of size 2 where the first element is the (literal) number ==1== and the second the (literal) string =='here'==.
 
 [[[testcase=true
 #(1 'here') size
 >>> 2
 ]]]
 
-Now, if you execute the expression ==#(1+2)==, you do not get an array with a
-single element ==3== but instead you get the array ==#(1 #+ 2)== i.e., with
-three elements: ==1==, the symbol ==#+== and the number ==2==.
+Now, if you execute the expression ==#(1+2)==, you do not get an array with a single element ==3== but instead you get the array ==#(1 #+ 2)== i.e., with three elements: ==1==, the symbol ==#+== and the number ==2==.
 
 [[[testcase=true
 #(1+2)
 >>>  #(1 #+ 2)
 ]]]
 
-This occurs because the construct ==#()== does not execute the expressions it
-contains.  The elements are only objects that are created when parsing the
-expression (called literal objects). The expression is scanned and the resulting
-elements are fed to a new array. Literal arrays contain numbers, ==nil==,
-==true==, ==false==, symbols, strings and other literal arrays. During the
-execution of ==#()== expressions, there are no messages sent.
+This occurs because the construct ==#()== does not execute the expressions it contains.  The elements are only objects that are created when parsing the expression (called literal objects). The expression is scanned and the resulting elements are fed to a new array. Literal arrays contain numbers, ==nil==,
+==true==, ==false==, symbols, strings and other literal arrays. During the execution of ==#()== expressions, there are no messages sent.
 
 !!!!Dynamic creation with =={ . }==
 
-Finally, you can create a dynamic array using the construct =={ . }==. The
-expression =={ a . b }== is totally equivalent to ==Array with: a with: b==.
-This means in particular that the expressions enclosed by =={== and ==}== are
-executed (contrary to the case of ==#()==).
+Finally, you can create a dynamic array using the construct =={ . }==. The expression =={ a . b }== is totally equivalent to ==Array with: a with: b==. This means in particular that the expressions enclosed by =={== and ==}== are executed (contrary to the case of ==#()==).
 
 [[[language=smalltalk|testcase=true
 { 1 + 2 }
@@ -334,8 +260,7 @@ executed (contrary to the case of ==#()==).
 
 !!!!Element Access
 
-Elements of all sequenceable collections can be accessed with messages ==at:
-anIndex== and ==at: anIndex put: anObject==.
+Elements of all sequenceable collections can be accessed with messages ==at: anIndex== and ==at: anIndex put: anObject==.
 
 [[[testcase=true
 | anArray |
@@ -346,19 +271,11 @@ anArray at: 3
 >>> 33
 ]]]
 
-Be careful: general principle is that literal arrays are not be modified! Literal arrays
-are kept in compiled method literal frames (a space where literals appearing in
-a method are stored), therefore unless you copy the array, the second time you
-execute the code your ''literal'' array may not have the value you expect. In
-the example, without copying the array, the second time around, the literal
-==#(1 2 3 4 5 6)== will actually be ==#(1 2 33 4 5 6)==! Dynamic arrays do not
-have this problem because they are not stored in literal frames.
+Be careful: general principle is that literal arrays are not be modified! Literal arrays are kept in compiled method literal frames (a space where literals appearing in a method are stored), therefore unless you copy the array, the second time you execute the code your ''literal'' array may not have the value you expect. In the example, without copying the array, the second time around, the literal ==#(1 2 3 4 5 6)== will actually be ==#(1 2 33 4 5 6)==! Dynamic arrays do not have this problem because they are not stored in literal frames.
 
 !!!==OrderedCollection==
 
-==OrderedCollection== is one of the collections that can grow, and to which
-elements can be added sequentially. It offers a variety of messages such as
-==add:==, ==addFirst:==, ==addLast:==, and ==addAll:==.
+==OrderedCollection== is one of the collections that can grow, and to which elements can be added sequentially. It offers a variety of messages such as ==add:==, ==addFirst:==, ==addLast:==, and ==addAll:==.
 
 [[[testcase=true
 | ordCol |
@@ -370,9 +287,7 @@ ordCol
 
 !!!!Removing Elements
 
-The message ==remove:== ==anObject== removes the first occurrence of an object
-from the collection. If the collection does not include such an object, it
-raises an error.
+The message ==remove:== ==anObject== removes the first occurrence of an object from the collection. If the collection does not include such an object, it raises an error.
 
 [[[testcase=true
 ordCol add: 'GitHub'.
@@ -381,9 +296,7 @@ ordCol
 >>> an OrderedCollection('Seaside' 'SmalltalkHub' 'GitHub')
 ]]]
 
-There is a variant of ==remove:== named ==remove:ifAbsent:== that allows one to
-specify as second argument a block that is executed in case the element to be
-removed is not in the collection.
+There is a variant of ==remove:== named ==remove:ifAbsent:== that allows one to specify as second argument a block that is executed in case the element to be removed is not in the collection.
 
 [[[testcase=true
 result := ordCol remove: 'zork' ifAbsent: [33].
@@ -393,8 +306,7 @@ result
 
 !!!!Conversion
 
-It is possible to get an ==OrderedCollection== from an ==Array== (or any other
-collection) by sending the message ==asOrderedCollection==:
+It is possible to get an ==OrderedCollection== from an ==Array== (or any other collection) by sending the message ==asOrderedCollection==:
 
 [[[testcase=true
 #(1 2 3) asOrderedCollection
@@ -407,24 +319,21 @@ collection) by sending the message ==asOrderedCollection==:
 
 !!!==Interval==
 
-The class ==Interval== represents ranges of numbers. For example, the interval
-of numbers from 1 to 100 is defined as follows:
+The class ==Interval== represents ranges of numbers. For example, the interval of numbers from 1 to 100 is defined as follows:
 
 [[[testcase=true
 Interval from: 1 to: 100
 >>> (1 to: 100)
 ]]]
 
-The result of ==printString== reveals that the class ==Number== provides
-us with a convenience method called ==to:== to generate intervals:
+The result of ==printString== reveals that the class ==Number== provides us with a convenience method called ==to:== to generate intervals:
 
 [[[testcase=true
 (Interval from: 1 to: 100) = (1 to: 100)
 >>> true
 ]]]
 
-We can use ==Interval class>>from:to:by:== or ==Number>>to:by:== to specify the
-step between two numbers as follow:
+We can use ==Interval class>>from:to:by:== or ==Number>>to:by:== to specify the step between two numbers as follow:
 
 [[[testcase=true
 (Interval from: 1 to: 100 by: 0.5) size
@@ -441,10 +350,7 @@ step between two numbers as follow:
 
 !!!==Dictionary==
 
-Dictionaries are important collections whose elements are accessed using keys.
-Among the most commonly used messages of dictionary you will find ==at: aKey==,
-==at: aKey put: aValue==, ==at: aKey ifAbsent: aBlock==, ==keys==, and
-==values==.
+Dictionaries are important collections whose elements are accessed using keys. Among the most commonly used messages of dictionary you will find ==at: aKey==, ==at: aKey put: aValue==, ==at: aKey ifAbsent: aBlock==, ==keys==, and ==values==.
 
 [[[testcase=true
 | colors |
@@ -466,16 +372,9 @@ colors values
 >>> {Color red . Color blue . Color yellow}
 ]]]
 
-Dictionaries compare keys by equality. Two keys are considered to be the same if
-they return true when compared using ==\===. A common and difficult to spot bug
-is to use as key an object whose ==\=== method has been redefined but not its
-==hash== method. Both methods are used in the implementation of dictionary and
-when comparing objects.
+Dictionaries compare keys by equality. Two keys are considered to be the same if they return true when compared using ==\===. A common and difficult to spot bug is to use as key an object whose ==\=== method has been redefined but not its ==hash== method. Both methods are used in the implementation of dictionary and when comparing objects.
 
-In its implementation, a ==Dictionary== can be seen as consisting of a set of
-(key value) associations created using the message ==->==. We can create a
-==Dictionary== from a collection of associations, or we may convert a dictionary
-to an array of associations.
+In its implementation, a ==Dictionary== can be seen as consisting of a set of (key value) associations created using the message ==->==. We can create a ==Dictionary== from a collection of associations, or we may convert a dictionary to an array of associations.
 
 [[[testcase=true
 | colors |
@@ -487,15 +386,9 @@ colors associations
 
 !!!==IdentityDictionary==
 
-While a dictionary uses the result of the messages ==\=== and ==hash== to
-determine if two keys are the same, the class ==IdentityDictionary== uses the
-identity (message ==\=\===) of the key instead of its values, i.e., it
-considers two keys to be equal ''only'' if they are the same object.
+While a dictionary uses the result of the messages ==\=== and ==hash== to determine if two keys are the same, the class ==IdentityDictionary== uses the identity (message ==\=\===) of the key instead of its values, i.e., it considers two keys to be equal ''only'' if they are the same object.
 
-Often ==Symbol==s are used as keys, in which case it is natural to use an
-==IdentityDictionary==, since a ==Symbol== is guaranteed to be globally unique.
-If, on the other hand, your keys are ==String==s, it is better to use a plain
-==Dictionary==, or you may get into trouble:
+Often ==Symbol==s are used as keys, in which case it is natural to use an ==IdentityDictionary==, since a ==Symbol== is guaranteed to be globally unique. If, on the other hand, your keys are ==String==s, it is better to use a plain ==Dictionary==, or you may get into trouble:
 
 [[[testcase=true
 a := 'foobar'.
@@ -516,15 +409,10 @@ trouble at: 'foobar'
 >>> 'a'
 ]]]
 
-Since ==a== and ==b== are different objects, they are treated as different
-objects. Interestingly, the literal =='foobar'== is allocated just once, so is
-really the same object as ==a==. You don't want your code to depend on behaviour
-like this! A plain ==Dictionary== would give the same value for any key equal to
+Since ==a== and ==b== are different objects, they are treated as different objects. Interestingly, the literal =='foobar'== is allocated just once, so is really the same object as ==a==. You don't want your code to depend on behaviour like this! A plain ==Dictionary== would give the same value for any key equal to
 =='foobar'==.
 
-Use only globally unique objects (like ==Symbol==s or ==SmallInteger==s) as keys
-for an ==IdentityDictionary==, and ==String==s (or other objects) as keys for a
-plain ==Dictionary==.
+Use only globally unique objects (like ==Symbol==s or ==SmallInteger==s) as keys for an ==IdentityDictionary==, and ==String==s (or other objects) as keys for a plain ==Dictionary==.
 
 !!!! IdentityDictionary example 
 
@@ -535,16 +423,11 @@ Smalltalk globals keys collect: [ :each | each class ] as: Set
 >>> a Set(ByteSymbol)
 ]]]
 
-Here we are using ==collect:as:== to specify the result collection to be of
-class ==Set==, that way we collect each kind of class used as a key only once.
+Here we are using ==collect:as:== to specify the result collection to be of class ==Set==, that way we collect each kind of class used as a key only once.
 
 !!!==Set==
 
-The class ==Set== is a collection which behaves as a mathematical set, i.e.,
-as a collection with no duplicate elements and without any order.
-In a ==Set==, elements are added using the message ==add:== and they cannot be accessed using
-the message ==at:==.
-Objects put in a set should implement the methods ==hash== and ==\===.
+The class ==Set== is a collection which behaves as a mathematical set, i.e., as a collection with no duplicate elements and without any order. In a ==Set==, elements are added using the message ==add:== and they cannot be accessed using the message ==at:==. Objects put in a set should implement the methods ==hash== and ==\===.
 
 [[[testcase=true
 s := Set new.
@@ -553,8 +436,7 @@ s size
 >>> 2
 ]]]
 
-You can also create sets using ==Set class>>newFrom:== or the conversion message
-==Collection>>asSet==:
+You can also create sets using ==Set class>>newFrom:== or the conversion message ==Collection>>asSet==:
 
 [[[testcase=true
 (Set newFrom: #( 1 2 3 1 4 )) = #(1 2 3 4 3 2 1) asSet
@@ -577,10 +459,7 @@ A ==Bag== is much like a ==Set== except that it does allow duplicates:
 >>> 3
 ]]]
 
-The set operations ''union'', ''intersection'' and ''membership test'' are
-implemented by the ==Collection== messages ==union:==, ==intersection:==, and
-==includes:==. The receiver is first converted to a ==Set==, so these operations
-work for all kinds of collections!
+The set operations ''union'', ''intersection'' and ''membership test'' are implemented by the ==Collection== messages ==union:==, ==intersection:==, and ==includes:==. The receiver is first converted to a ==Set==, so these operations work for all kinds of collections!
 
 [[[testcase=true
 (1 to: 6) union: (4 to: 10)
@@ -597,28 +476,21 @@ work for all kinds of collections!
 >>> true
 ]]]
 
-As we explain below, elements of a set are accessed using iterators (see Section
-*@sec:iterators*).
+As we explain below, elements of a set are accessed using iterators (see Section *@sec:iterators*).
 
 !!!==SortedCollection==
 
-In contrast to an ==OrderedCollection==, a ==SortedCollection== maintains its
-elements in sort order. By default, a sorted collection uses the message ==<\===
-to establish sort order, so it can sort instances of subclasses of the abstract
-class ==Magnitude==, which defines the protocol of comparable objects (==<==,
-==\===, ==>==, ==>\===, ==between:and:==...).
-(See Chapter *: Basic Classes>../BasicClasses/BasicClasses.pier@cha:basicClasses*).
+In contrast to an ==OrderedCollection==, a ==SortedCollection== maintains its elements in sort order. By default, a sorted collection uses the message ==<\=== to establish sort order, so it can sort instances of subclasses of the abstract class ==Magnitude==, which defines the protocol of comparable objects (==<==,
+==\===, ==>==, ==>\===, ==between:and:==...). (See Chapter *: Basic Classes>../BasicClasses/BasicClasses.pier@cha:basicClasses*).
 
-You can create a ==SortedCollection== by creating a new instance and adding
-elements to it:
+You can create a ==SortedCollection== by creating a new instance and adding elements to it:
 
 [[[testcase=true
 SortedCollection new add: 5; add: 2; add: 50; add: -10; yourself.
 >>> a SortedCollection(-10 2 5 50)
 ]]]
 
-More usually, though, one will send the conversion message
-==asSortedCollection== to an existing collection:
+More usually, though, one will send the conversion message ==asSortedCollection== to an existing collection:
 
 [[[language=smalltalk|testcase=true
 #(5 2 50 -10) asSortedCollection
@@ -630,16 +502,14 @@ More usually, though, one will send the conversion message
 >>> a SortedCollection($e $h $l $l $o)
 ]]]
 
-How do you get a ==String== back from this result? ==asString== unfortunately
-returns the ==printString== representation, which is not what we want:
+How do you get a ==String== back from this result? ==asString== unfortunately returns the ==printString== representation, which is not what we want:
 
 [[[testcase=true
 'hello' asSortedCollection asString
 >>> 'a SortedCollection($e $h $l $l $o)'
 ]]]
 
-The correct answer is to either use ==String class>>newFrom:==, ==String
-class>>withAll:== or ==Object>>as:==.
+The correct answer is to either use ==String class>>newFrom:==, ==String class>>withAll:== or ==Object>>as:==.
 
 [[[testcase=true
 'hello' asSortedCollection as: String
@@ -654,9 +524,7 @@ String withAll: 'hello' asSortedCollection
 >>> 'ehllo'
 ]]]
 
-It is possible to have different kinds of elements in a ==SortedCollection== as
-long as they are all comparable. For example, we can mix different kinds of
-numbers such as integers, floats and fractions:
+It is possible to have different kinds of elements in a ==SortedCollection== as long as they are all comparable. For example, we can mix different kinds of numbers such as integers, floats and fractions:
 
 
 [[[language=smalltalk|testcase=true
@@ -664,12 +532,7 @@ numbers such as integers, floats and fractions:
 >>> a SortedCollection((-2/3) 5 5.21)
 ]]]
 
-Imagine that you want to sort objects that do not define the method ==<\=== or
-that you would like to have a different sorting criterion. You can do this by
-supplying a two argument block, called a sortblock, to the sorted collection.
-For example, the class ==Color== is not a Magnitude and it does not implement
-the method ==<\===, but we can specify a block stating that the colors should be
-sorted according to their luminance (a measure of brightness).
+Imagine that you want to sort objects that do not define the method ==<\=== or that you would like to have a different sorting criterion. You can do this by supplying a two argument block, called a sortblock, to the sorted collection. For example, the class ==Color== is not a Magnitude and it does not implement the method ==<\===, but we can specify a block stating that the colors should be sorted according to their luminance (a measure of brightness).
 
 [[[testcase=true
 col := SortedCollection
@@ -681,11 +544,7 @@ col
 
 !!!==Strings==
 
-In Pharo, a ==String== is a collection of ==Character==s. It is
-sequenceable, indexable, mutable and homogeneous, containing only ==Character==
-instances. Like ==Array==s, ==String==s have a dedicated syntax, and are
-normally created by directly specifying a ==String== literal within single
-quotes, but the usual collection creation methods will work as well.
+In Pharo, a ==String== is a collection of ==Character==s. It is sequenceable, indexable, mutable and homogeneous, containing only ==Character== instances. Like ==Array==s, ==String==s have a dedicated syntax, and are normally created by directly specifying a ==String== literal within single quotes, but the usual collection creation methods will work as well.
 
 [[[testcase=true
 'Hello'
@@ -707,14 +566,9 @@ String newFrom: #($h $e $l $l $o)
 >>> 'hello'
 ]]]
 
-In actual fact, ==String== is abstract. When we instantiate a ==String== we
-actually get either an 8-bit ==ByteString== or a 32-bit ==WideString==. To keep
-things simple, we usually ignore the difference and just talk about instances of
-==String==.
+In actual fact, ==String== is abstract. When we instantiate a ==String== we actually get either an 8-bit ==ByteString== or a 32-bit ==WideString==. To keep things simple, we usually ignore the difference and just talk about instances of ==String==.
 
-While strings are delimited by single quotes, a string can contain a single
-quote: to define a string with a single quote we should type it twice. Note that
-the string will contain only one element and not two as shown below:
+While strings are delimited by single quotes, a string can contain a single quote: to define a string with a single quote we should type it twice. Note that the string will contain only one element and not two as shown below:
 
 [[[testcase=true
 'l''idiot' at: 2
@@ -726,8 +580,7 @@ the string will contain only one element and not two as shown below:
 >>> $i
 ]]]
 
-The message ==,== concatenates two instances of ==String==. 
-Such messages can chained as follows: 
+The message ==,== concatenates two instances of ==String==. Such messages can chained as follows: 
 
 [[[testcase=true
 s := 'no', ' ', 'worries'.
@@ -735,9 +588,7 @@ s
 >>> 'no worries'
 ]]]
 
-Since a string is a mutable collection we can also change it using the message
-==at:put:==.
-From a design point of view better avoid mutating strings since strings are often shared over method execution.
+Since a string is a mutable collection we can also change it using the message ==at:put:==. From a design point of view better avoid mutating strings since strings are often shared over method execution.
 
 [[[testcase=true
 s at: 4 put: $h; at: 5 put: $u.
@@ -745,17 +596,14 @@ s
 >>> 'no hurries'
 ]]]
 
-Note that the comma method is defined by ==Collection==, so it will work for any
-kind of collection!
+Note that the comma method is defined by ==Collection==, so it will work for any kind of collection!
 
 [[[testcase=true
 (1 to: 3), '45'
 >>> #(1 2 3 $4 $5)
 ]]]
 
-We can also modify an existing string using ==replaceAll:with:== or
-==replaceFrom:to:with:== as shown below. Note that the number of characters and
-the interval should have the same size.
+We can also modify an existing string using ==replaceAll:with:== or ==replaceFrom:to:with:== as shown below. Note that the number of characters and the interval should have the same size.
 
 [[[testcase=true
 s replaceAll: $n with: $N.
@@ -769,18 +617,14 @@ s
 >>> 'No worries'
 ]]]
 
-In contrast to the methods described above, the method ==copyReplaceAll:==
-creates a new string. (Curiously, here the arguments are substrings rather than
-individual characters, and their sizes do not have to match.)
+In contrast to the methods described above, the method ==copyReplaceAll:== creates a new string. (Curiously, here the arguments are substrings rather than individual characters, and their sizes do not have to match.)
 
 [[[testcase=true
 s copyReplaceAll: 'rries' with: 'mbats'
 >>> 'No wombats'
 ]]]
 
-A quick look at the implementation of these methods reveals that they are
-defined not only for ==String==s, but for any kind of
-==SequenceableCollection==, so the following also works:
+A quick look at the implementation of these methods reveals that they are defined not only for ==String==s, but for any kind of ==SequenceableCollection==, so the following also works:
 
 [[[testcase=true
 (1 to: 6) copyReplaceAll: (3 to: 5) with: { 'three' . 'etc.' }
@@ -789,10 +633,7 @@ defined not only for ==String==s, but for any kind of
 
 !!!!String matching
 
-It is possible to ask whether a pattern matches a string by sending the
-==match:== message. The pattern can use ==*== to match an arbitrary series of
-characters and ==#== to match a single character. Note that ==match:== is sent
-to the pattern and not the string to be matched.
+It is possible to ask whether a pattern matches a string by sending the ==match:== message. The pattern can use ==*== to match an arbitrary series of characters and ==#== to match a single character. Note that ==match:== is sent to the pattern and not the string to be matched.
 
 [[[testcase=true
 'Linux *' match: 'Linux mag'
@@ -804,13 +645,10 @@ to the pattern and not the string to be matched.
 >>> true
 ]]]
 
-More advanced pattern matching facilities are also available in the ==Regex==
-package.
+More advanced pattern matching facilities are also available in the ==Regex== package.
 
 !!!!Substrings
-For substring manipulation we can use messages like ==first==, ==first:==,
-==allButFirst:==, ==copyFrom:to:== and others, defined in
-==SequenceableCollection==.
+For substring manipulation we can use messages like ==first==, ==first:==, ==allButFirst:==, ==copyFrom:to:== and others, defined in ==SequenceableCollection==.
 
 [[[testcase=true
 'alphabet' at: 6
@@ -842,12 +680,8 @@ For substring manipulation we can use messages like ==first==, ==first:==,
 >>> 'p' (not $p)
 ]]]
 
-Be aware that result type can be different, depending on the method used. Most
-of the substring-related methods return ==String== instances. But the messages
-that always return one element of the ==String== collection, return a
-==Character== instance (for example, =='alphabet' at: 6== returns the character
-==$b==). For a complete list of substring-related messages, browse the
-==SequenceableCollection== class (especially the ==accessing== protocol).
+Be aware that result type can be different, depending on the method used. Most of the substring-related methods return ==String== instances. But the messages that always return one element of the ==String== collection, return a ==Character== instance (for example, =='alphabet' at: 6== returns the character
+==$b==). For a complete list of substring-related messages, browse the ==SequenceableCollection== class (especially the ==accessing== protocol).
 
 !!!!Some predicates on strings
 
@@ -877,18 +711,14 @@ generally on collections.
 
 !!!!String templating
 
-There are three messages that are useful to manage string templating:
-==format:==, ==expandMacros==, and ==expandMacrosWith:==.
+There are three messages that are useful to manage string templating: ==format:==, ==expandMacros==, and ==expandMacrosWith:==.
 
 [[[testcase=true
 '{1} is {2}' format: {'Pharo' . 'cool'}
 >>> 'Pharo is cool'
 ]]]
 
-The messages of the ==expandMacros== family offer variable substitution, using
-==<n>== for carriage return, ==<t>== for tabulation, ==<1s>==, ==<2s>==,
-==<3s>== for arguments (==<1p>==, ==<2p>==, surrounds the string with single
-quotes), and ==<1?value1:value2>== for conditional.
+The messages of the ==expandMacros== family offer variable substitution, using ==<n>== for carriage return, ==<t>== for tabulation, ==<1s>==, ==<2s>==, ==<3s>== for arguments (==<1p>==, ==<2p>==, surrounds the string with single quotes), and ==<1?value1:value2>== for conditional.
 
 [[[testcase=true
 'look-<t>-here' expandMacros
@@ -922,8 +752,7 @@ quotes), and ==<1?value1:value2>== for conditional.
 
 !!!!Some other utility methods
 
-The class ==String== offers numerous other utilities including the messages
-==asLowercase==, ==asUppercase== and ==capitalized==.
+The class ==String== offers numerous other utilities including the messages ==asLowercase==, ==asUppercase== and ==capitalized==.
 
 [[[testcase=true
 'XYZ' asLowercase
@@ -955,13 +784,9 @@ The class ==String== offers numerous other utilities including the messages
 >>> 'this sent...too long'
 ]]]
 
-
 !!!! ==asString== vs. ==printString==
 
-Note that there is generally a difference between asking an object its string
-representation by sending the message ==printString== and converting it to a
-string by sending the message ==asString==. Here is an example of the
-difference.
+Note that there is generally a difference between asking an object its string representation by sending the message ==printString== and converting it to a string by sending the message ==asString==. Here is an example of the difference.
 
 [[[testcase=true
 #ASymbol printString
@@ -973,22 +798,12 @@ difference.
 >>> 'ASymbol'
 ]]]
 
-A symbol is similar to a string but is guaranteed to be globally unique. For
-this reason symbols are preferred to strings as keys for dictionaries, in
-particular for instances of ==IdentityDictionary==. See also
-Chapter *: Basic Classes>../BasicClasses/BasicClasses.pier@cha:basicClasses* for
-more about ==String== and ==Symbol==.
+A symbol is similar to a string but is guaranteed to be globally unique. For this reason symbols are preferred to strings as keys for dictionaries, in particular for instances of ==IdentityDictionary==. See also Chapter *: Basic Classes>../BasicClasses/BasicClasses.pier@cha:basicClasses* for more about ==String== and ==Symbol==.
 
 !!!Collection iterators
 @sec:iterators
 
-In Pharo loops and conditionals are simply messages sent to collections or other
-objects such as integers or blocks (see also Chapter
-*: Understanding message syntax>../UnderstandingMessage/UnderstandingMessage.pillar@chapterUnderstandingMessage*).
-In addition to low-level messages such as ==to:do:== which evaluates a block
-with an argument ranging from an initial to a final number, the collection
-hierarchy offers various high-level iterators. Using such iterators will make
-your code more robust and compact.
+In Pharo loops and conditionals are simply messages sent to collections or other objects such as integers or blocks (see also Chapter *: Understanding message syntax>../UnderstandingMessage/UnderstandingMessage.pillar@chapterUnderstandingMessage*). In addition to low-level messages such as ==to:do:== which evaluates a block with an argument ranging from an initial to a final number, the collection hierarchy offers various high-level iterators. Using such iterators will make your code more robust and compact.
 
 !!!!Iterating (==do:)==
 
@@ -1002,13 +817,9 @@ example prints all the strings contained in the receiver to the transcript.
 
 !!!!Variants
 
-There are a lot of variants of ==do:==, such as ==do:without:==,
-==doWithIndex:== and ==reverseDo:==.
+There are a lot of variants of ==do:==, such as ==do:without:==, ==doWithIndex:== and ==reverseDo:==.
 
-For the indexed collections (==Array==, ==OrderedCollection==,
-==SortedCollection==) the message ==doWithIndex:== also gives access to the
-current index. This message is related to ==to:do:== which is defined in class
-==Number==.
+For the indexed collections (==Array==, ==OrderedCollection==, ==SortedCollection==) the message ==doWithIndex:== also gives access to the current index. This message is related to ==to:do:== which is defined in class ==Number==.
 
 
 [[[testcase=true
@@ -1017,11 +828,9 @@ current index. This message is related to ==to:do:== which is defined in class
 >>> 2
 ]]]
 
-For ordered collections, the message ==reverseDo:== walks the collection in the
-reverse order.
+For ordered collections, the message ==reverseDo:== walks the collection in the reverse order.
 
-The following code shows an interesting message: ==do:separatedBy:== which
-executes the second block only in between two elements.
+The following code shows an interesting message: ==do:separatedBy:== which executes the second block only in between two elements.
 
 [[[testcase=true
 | res |
@@ -1045,10 +854,7 @@ String streamContents: [ :stream |
 
 !!!!Dictionaries
 
-When the message ==do:== is sent to a dictionary, the elements taken into
-account are the values, not the associations. The proper messages to use are
-==keysDo:==, ==valuesDo:==, and ==associationsDo:==, which iterate respectively
-on keys, values or associations.
+When the message ==do:== is sent to a dictionary, the elements taken into account are the values, not the associations. The proper messages to use are ==keysDo:==, ==valuesDo:==, and ==associationsDo:==, which iterate respectively on keys, values or associations.
 
 [[[testcase=true
 colors := Dictionary newFrom: { #yellow -> Color yellow. #blue -> Color blue. #red -> Color red }.
@@ -1057,16 +863,11 @@ colors valuesDo: [ :value | Transcript show: value; cr ].
 colors associationsDo: [:value | Transcript show: value; cr].
 ]]]
 
-
 !!! Collecting results (==collect:==)
 
-If you want to apply a function to the elements of a collection and get a new
-collection with the results, rather than using ==do:==, you are probably better
-off using ==collect:==, or one of the other iterator methods. Most of these can
-be found in the ==enumerating== protocol of ==Collection== and its subclasses.
+If you want to apply a function to the elements of a collection and get a new collection with the results, rather than using ==do:==, you are probably better off using ==collect:==, or one of the other iterator methods. Most of these can be found in the ==enumerating== protocol of ==Collection== and its subclasses.
 
-Imagine that we want a collection containing the doubles of the elements in
-another collection. Using the method ==do:== we must write the following:
+Imagine that we want a collection containing the doubles of the elements in another collection. Using the method ==do:== we must write the following:
 
 [[[testcase=true
 | double |
@@ -1076,18 +877,14 @@ double
 >>> an OrderedCollection(2 4 6 8 10 12)
 ]]]
 
-The message ==collect:== executes its argument block for each element and
-returns a new collection containing the results. Using ==collect:== instead, the
-code is much simpler:
+The message ==collect:== executes its argument block for each element and returns a new collection containing the results. Using ==collect:== instead, the code is much simpler:
 
 [[[testcase=true
 #(1 2 3 4 5 6) collect: [ :e | 2 * e ]
 >>> #(2 4 6 8 10 12)
 ]]]
 
-The advantages of ==collect:== over ==do:== are even more important in the
-following example, where we take a collection of integers and generate as a
-result a collection of absolute values of these integers:
+The advantages of ==collect:== over ==do:== are even more important in the following example, where we take a collection of integers and generate as a result a collection of absolute values of these integers:
 
 [[[testcase=true
 aCol :=  #( 2 -3 4 -35 4 -11).
@@ -1105,30 +902,23 @@ Contrast the above with the much simpler following expression:
 >>> #(2 3 4 35 4 11)
 ]]]
 
-A further advantage of the second solution is that it will also work for sets
-and bags. Generally you should avoid using ==do:==, unless you want to send
-messages to each of the elements of a collection.
+A further advantage of the second solution is that it will also work for sets and bags. Generally you should avoid using ==do:==, unless you want to send messages to each of the elements of a collection.
 
-Note that sending the message ==collect:== returns the same kind of collection
-as the receiver. For this reason the following code fails. (A ==String== cannot
-hold integer values.)
+Note that sending the message ==collect:== returns the same kind of collection as the receiver. For this reason the following code fails. (A ==String== cannot hold integer values.)
 
 [[[testcase=true
 'abc' collect: [ :ea | ea asciiValue ]
 >>> "error!"
 ]]]
 
-Instead we must first convert the string to an ==Array== or an
-==OrderedCollection==:
+Instead we must first convert the string to an ==Array== or an ==OrderedCollection==:
 
 [[[testcase=true
 'abc' asArray collect: [ :ea | ea asciiValue ]
 >>> #(97 98 99)
 ]]]
 
-Actually ==collect:== is not guaranteed to return a collection of exactly the
-same class as the receiver, but only the same ''species''. In the case of
-an ==Interval==, the species is an ==Array==!
+Actually ==collect:== is not guaranteed to return a collection of exactly the same class as the receiver, but only the same ''species''. In the case of an ==Interval==, the species is an ==Array==!
 
 [[[testcase=true
 (1 to: 5) collect: [ :ea | ea * 2 ]
@@ -1137,8 +927,7 @@ an ==Interval==, the species is an ==Array==!
 
 !!!Selecting and rejecting elements
 
-The message ==select:== returns the elements of the receiver that satisfy a
-particular condition:
+The message ==select:== returns the elements of the receiver that satisfy a particular condition:
 
 [[[testcase=true
 (2 to: 20) select: [ :each | each isPrime ]
@@ -1153,16 +942,14 @@ The message ==reject:== does the opposite:
 
 !!!!Identifying an element with ==detect:==
 
-The message ==detect:== returns the first element of the receiver that matches
-block argument.
+The message ==detect:== returns the first element of the receiver that matches block argument.
 
 [[[testcase=true
 'through' detect: [ :each | each isVowel ]
 >>> $o
 ]]]
 
-The message ==detect:ifNone:== is a variant of the method ==detect:==. Its
-second block is evaluated when there is no element matching the block.
+The message ==detect:ifNone:== is a variant of the method ==detect:==. Its second block is evaluated when there is no element matching the block.
 
 [[[testcase=true
 Smalltalk globals allClasses
@@ -1173,18 +960,11 @@ Smalltalk globals allClasses
 
 !!!!Accumulating results with ==inject:into:==
 
-Functional programming languages often provide a higher-order function called
-''fold'' or ''reduce'' to accumulate a result by applying some binary operator
-iteratively over all elements of a collection. In Pharo this is done by
-==Collection>>inject:into:==.
+Functional programming languages often provide a higher-order function called ''fold'' or ''reduce'' to accumulate a result by applying some binary operator iteratively over all elements of a collection. In Pharo this is done by ==Collection>>inject:into:==.
 
-The first argument is an initial value, and the second argument is a
-two-argument block which is applied to the result this far, and each element in
-turn.
+The first argument is an initial value, and the second argument is a two-argument block which is applied to the result this far, and each element in turn.
 
-A trivial application of ==inject:into:== is to produce the sum of a collection
-of numbers. In Pharo we could write this expression to sum the
-first 100 integers:
+A trivial application of ==inject:into:== is to produce the sum of a collection of numbers. In Pharo we could write this expression to sum the first 100 integers:
 
 [[[testcase=true
 (1 to: 100) inject: 0 into: [ :sum :each | sum + each ]
@@ -1203,13 +983,12 @@ factorial value: 10
 ]]]
 
 !!!Other high-order messages
-There are many other iterator messages. You can check the ==Collection== class.
-Here is a selection.
+
+There are many other iterator messages. You can check the ==Collection== class. Here is a selection.
 
 !!!!!! ==count:==
 
-The message ==count:== returns the number of elements satisfying a condition.
-The condition is represented as a boolean block.
+The message ==count:== returns the number of elements satisfying a condition. The condition is represented as a boolean block.
 
 [[[testcase=true
 Smalltalk globals allClasses
@@ -1219,8 +998,7 @@ Smalltalk globals allClasses
 
 !!!!!! ==includes:==
 
-The message ==includes:== checks whether the argument is contained in the
-collection.
+The message ==includes:== checks whether the argument is contained in the collection.
 
 [[[testcase=true
 | colors |
@@ -1231,14 +1009,12 @@ colors includes: Color blue.
 
 !!!!!! ==anySatisfy:==
 
-The message ==anySatisfy:== answers true if at least one element of the
-collection satisfies the condition represented by the argument.
+The message ==anySatisfy:== answers true if at least one element of the collection satisfies the condition represented by the argument.
 
 [[[testcase=true
 colors anySatisfy: [ :c | c red > 0.5 ]
 >>> true
 ]]]
-
 
 !!!A common mistake: using ==add:== result
 
@@ -1251,9 +1027,7 @@ collection
 >>> 2
 ]]]
 
-Here the variable ==collection== does not hold the newly created collection but
-rather the last number added. This is because the method ==add:== returns the
-element added and not the receiver.
+Here the variable ==collection== does not hold the newly created collection but rather the last number added. This is because the method ==add:== returns the element added and not the receiver.
 
 The following code yields the expected result:
 
@@ -1265,8 +1039,7 @@ collection
 >>> an OrderedCollection(1 2)
 ]]]
 
-You can also use the message ==yourself== to return the receiver of a cascade of
-messages:
+You can also use the message ==yourself== to return the receiver of a cascade of messages:
 
 [[[testcase=true
 | collection |
@@ -1276,8 +1049,7 @@ collection := OrderedCollection new add: 1; add: 2; yourself
 
 !!! A common mistake: Removing an element while iterating
 
-Another mistake you may make is to remove an element from a collection you are
-currently iterating over. The bugs created but such mistakes can be really difficult to spot because the iterating order may be change depending on the storage strategy of the collection. 
+Another mistake you may make is to remove an element from a collection you are currently iterating over. The bugs created but such mistakes can be really difficult to spot because the iterating order may be change depending on the storage strategy of the collection. 
 
 [[[testcase=true
 | range |
@@ -1301,12 +1073,8 @@ range
 
 !!! A common mitaske: Redefining ==\=== but not ==hash==
 
-A difficult error to spot is when you redefine ==\=== but not ==hash==. The
-symptoms are that you will lose elements that you put in sets or other strange
-behaviour. One solution proposed by Kent Beck is to use ==bitXor:== to redefine
-==hash==. Suppose that we want two books to be considered equal if their titles
-and authors are the same. Then we would redefine not only ==\=== but also
-==hash== as follows:
+A difficult error to spot is when you redefine ==\=== but not ==hash==. The symptoms are that you will lose elements that you put in sets or other strange behaviour. One solution proposed by Kent Beck is to use ==bitXor:== to redefine ==hash==. Suppose that we want two books to be considered equal if their titles
+and authors are the same. Then we would redefine not only ==\=== but also ==hash== as follows:
 
 [[[caption=Redefining ==\=== and ==hash==.
 Book >> = aBook
@@ -1317,14 +1085,11 @@ Book >> hash
    ^ title hash bitXor: authors hash
 ]]]
 
-Another nasty problem arises if you use a mutable object, i.e., an object
-that can change its hash value over time, as an element of a ==Set== or as a key
-to a ==Dictionary==. Don't do this unless you love debugging!
+Another nasty problem arises if you use a mutable object, i.e., an object that can change its hash value over time, as an element of a ==Set== or as a key to a ==Dictionary==. Don't do this unless you love debugging!
 
 !!!Chapter summary
 
-The collection hierarchy provides a common vocabulary for uniformly
-manipulating a variety of different kinds of collections.
+The collection hierarchy provides a common vocabulary for uniformly manipulating a variety of different kinds of collections.
 
 -A key distinction is between ==SequenceableCollection==s, which maintain their elements in a given order, ==Dictionary== and its subclasses, which maintain key-to-value associations, and ==Set==s and ==Bag==s, which are unordered.
 -You can convert most collections to another kind of collection by sending them the messages ==asArray==, ==asOrderedCollection==, etc...

--- a/Chapters/Counter/Exo-Counter.pillar
+++ b/Chapters/Counter/Exo-Counter.pillar
@@ -177,7 +177,7 @@ As you now have your first green test, it's a good time to save your work.
 
 !!!Saving your code as a git repository with Iceberg
 
-Saving your work in the Pharo image is good, but it's not idea for sharing your work or collaborating with others. Much of modern software development is mediated through git, an open source version control system. Services such as GitHub are built on top of git, providing places where developers can work together building open source projects - like Pharo!
+Saving your work in the Pharo image is good, but it's not ideal for sharing your work or collaborating with others. Much of modern software development is mediated through git, an open-source version control system. Services such as GitHub are built on top of git, providing places where developers can work together building open source projects - like Pharo!
 
 Pharo works with git through the tool ""Iceberg"". This section will show you how to create a local git repository for your code, commit your changes to it, and also push those changes to a remote repository such as GitHub.
 
@@ -187,23 +187,23 @@ Open Iceberg through the ""Sources"" menu, or by hitting ==Cmd-O,I==.
 
 +Iceberg ''Repositories'' browser on a fresh image indicates that if you want to version modifications to Pharo itself you will have to tell Iceberg where the Pharo clone is located. But you do not care.>file://figures/Save1-EmptyIceberg.png|width=75|label=EmptyIceberg+
 
-You should now see something similar to Figure *@EmptyIceberg* which shows the top level Iceberg pane. It shows the Pharo project, and a few other projects that also come with your image, and indicates that it could not find a local repository for them by showing 'Local repository missing'. You do not have to worry about the Pharo project or having a local repository if you do not want to contribute to Pharo.
+You should now see something similar to Figure *@EmptyIceberg* which shows the top-level Iceberg pane. It shows the Pharo project, and a few other projects that also come with your image, and indicates that it could not find a local repository for them by showing 'Local repository missing'. You do not have to worry about the Pharo project or having a local repository if you do not want to contribute to Pharo.
 
 We're going to create a new project of our own.
 
-!!!!Add and configure a project
+!!!! Add and configure a project
 
 Press the button ==Add== to create a new project. Select 'New Repository' from the left and you should see a configuration pane similar to the one in Figure *@CreateProject*. Here we name our project, declare a directory on our local disk where the project's source should be saved, and also a subdirectory in the project itself which will be used to keep the Pharo code in -  conventionally this is the ==src== directory.
 
 +Add and create a project named MyCounter and with the ==src== subdirectory.>file://figures/Save2-CreateProject.png|label=CreateProject+
 
-!!!!Add your package to the project
+!!!! Add your package to the project
 
 Once added, the Iceberg ''Working copy'' browser should show you an empty pane because we still haven't added any packages to our project. Click on the ""Add package"" button and select the package ==MyCounter== as shown by Figure *@AddingPackage*.
 
 +Selecting the Add package iconic button,  add your package MyCounter to your project.>file://figures/Save3-AddingPackage.png|label=AddingPackage+
 
-!!!!Commit your changes
+!!!! Commit your changes
 
 Once you package is added, Iceberg shows you that there is uncommitted code in the packages managed by your project, as shown in Figure  *@SaveUncommited*. Press the ""Commit"" button. Iceberg will show you all the changes that are about to be saved (Figure *@SaveUncommited*). Enter a commit message and commit your changes.
 
@@ -380,4 +380,4 @@ Now you ''really'' saved your code  will be able to reload from another machine 
 
 !!! Conclusion
 
-In this tutorial you learned how to define packages, classes, methods, and tests. The workflow of programming that we chose for this first tutorial is similar to most of programming languages. However in Pharo, smart and agile developers use a different workflow: Test-Driven Development (TDD). We suggest you now to redo this whole exercise by defining a test first, executing it, defining a method in the debugger, and then repeating. Watch the second "Counter" video of the Pharo MOOC available at *http://mooc.pharo.org* to get a better understanding of the workflow.
+In this tutorial, you learned how to define packages, classes, methods, and tests. The workflow of programming that we chose for this first tutorial is similar to most programming languages. However, in Pharo, smart and agile developers use a different workflow: Test-Driven Development (TDD). We suggest you redo this whole exercise by defining a test first, executing it, defining a method in the debugger, and then repeating. Watch the second "Counter" video of the Pharo MOOC available at *http://mooc.pharo.org* to get a better understanding of the workflow.

--- a/Chapters/FirstApplication/FirstApplication.pillar
+++ b/Chapters/FirstApplication/FirstApplication.pillar
@@ -1,7 +1,7 @@
 !!A first application
 @cha:firstApp
 
-In this chapter we will develop a simple game: Lights Out (*http://en.wikipedia.org/wiki/Lights_Out_(game)*). In doing so we will increase our familiarity with the Browser, the Inspector, the Debugger, and versioning code with Iceberg. It's important to become proficient with these core tools. Once again, we will encourage you to take a test-first approach to developing this game by using Test-Driven Development.
+In this chapter we will develop a simple game: Lights Out (*http://en.wikipedia.org/wiki/Lights_Out_(game)*). In doing so, we will increase our familiarity with the Browser, the Inspector, the Debugger, and versioning code with Iceberg. It's important to become proficient with these core tools. Once again, we will encourage you to take a test-first approach to developing this game by using Test-Driven Development.
 
 +The Lights Out game board.>file://figures/gameLO.png|width=30|label=fig:gameLO+
 
@@ -39,11 +39,11 @@ SimpleSwitchMorph subclass: #LOCell
 	package: 'PBE-LightsOut'
 ]]]
 
-Let's think for a minute about what you're looking at with this template. Is this a special form we fill in to create a class? Is it a new syntax? No, it's just another message being sent to another object! The message is ==subclass:instanceVariableNames:classVariableNames:package==, which is a bit of a mouthful, and we're sending it to the class ==SimpleSwitchMorph==. The arguments are all strings, apart from the name of the subclass we're creating, which is a symbol ==#LOCell==. The package is our new package, and the ==mouseAction== instance variable is going to be used to define what action the cell should take when it gets clicked on.
+Let's think for a minute about what you're looking at with this template. Is this a special form we fill in to create a class? Is it a new syntax? No, it's just another message being sent to another object! The message is ==subclass:instanceVariableNames:classVariableNames:package==, which is a bit of a mouthful, and we're sending it to the class ==SimpleSwitchMorph==. The arguments are all strings, apart from the name of the subclass we're creating, which is the symbol ==#LOCell==. The package is our new package, and the ==mouseAction== instance variable is going to be used to define what action the cell should take when it gets clicked on.
 
-So why are we subclassing ==SimpleSwitchMorph== rather than ==Object==? We'll see benefits of subclassing already specialized classes very soon. And we'll find out what that ==mouseAction== instance variable is all about.
+So why are we subclassing ==SimpleSwitchMorph== rather than ==Object==? We'll see the benefits of subclassing already specialized classes very soon. And we'll find out what that ==mouseAction== instance variable is all about.
 
-To send the message, accept the code either through the menu or the ==Cmd-S== shortcut. The message sends, the new class compiles, and we get something like *@fig:pannelAtNewClass*.
+To send the message, accept the code either through the menu or the ==Cmd-S== shortcut. The message is sent, the new class compiles, and we get something like *@fig:pannelAtNewClass*.
 
 +The newly-created class LOCell.>file://figures/pannelAtNewClass.png|width=100|label=fig:pannelAtNewClass+
 
@@ -55,11 +55,11 @@ Pharoers put a very high value on the readability of their code to help explain 
 
 !!!!Method comments
 
-There's been a tendency in the recent past to believe that well written, expressive methods don't need comments; the intent and meaning should be obvious just by reading it. This is just plain wrong and encourages sloppiness. Of course, crufty and hard to understand code should be worked on, renamed, and refactored. A good comment does not excuse hard to read code. And obviously writing comments for trivial methods makes no sense; a comment should not just be the code written again in English. Your comments should aim to be an explanation of what the method is doing, its context, and possibly the rationale behind its implementation. A reader should be comforted by your comment, is should show that what they assumed about the code was correct and should dispel any confusion they might have.
+There's been a tendency in the recent past to believe that well-written, expressive methods don't need comments; the intent and meaning should be obvious just by reading it. This is just plain wrong and encourages sloppiness. Of course, crufty and hard-to-understand code should be worked on, renamed, and refactored. A good comment does not excuse hard to read code. And obviously, writing comments for trivial methods makes no sense; a comment should not just be the code written again in English. Your comments should aim to be an explanation of what the method is doing, its context, and possibly the rationale behind its implementation. A reader should be comforted by your comment, is should show that what they assumed about the code was correct and should dispel any confusion they might have.
 
 !!!!Class comments
 
-For the class comment, the Pharo offers you a template with some suggestions of what makes a good class comment. So read it! The format is based on Class (or Candidate) Responsibility Collaborator cards (CRC cards), developed by Kent Beck and Ward Cunningham from many influences while they were working in Smalltalk in the 1980s (see their paper *"A Laboratory For Teaching Object-Oriented Thinking">https://c2.com/doc/oopsla89/paper.html* for more details). In a nutshell the idea is to  state the ''responsibility'' of the class in a couple of sentences, and how it ''collaborates'' with other classes to achieve this. In addition we can state the class' API (the main messages an object understands), give an example of the class being used (usually in Pharo we define examples as class methods), and some details about the internal representation or the rationale behind the implementation.
+For the class comment, the Pharo offers you a template with some suggestions on what makes a good class comment. So, read it! The format is based on Class (or Candidate) Responsibility Collaborator cards (CRC cards), developed by Kent Beck and Ward Cunningham from many influences while they were working in Smalltalk in the 1980s (see their paper *"A Laboratory For Teaching Object-Oriented Thinking">https://c2.com/doc/oopsla89/paper.html* for more details). In a nutshell, the idea is to  state the ''responsibility'' of the class in a couple of sentences, and how it ''collaborates'' with other classes to achieve this. In addition, we can state the class' API (the main messages an object understands), give an example of the class being used (usually in Pharo we define examples as class methods), and some details about the internal representation or the rationale behind the implementation.
 
 !!!Adding methods to a class
 
@@ -91,7 +91,7 @@ First off, it's another ==initialize== method as we saw with our counter in the 
 
 !!!!!Invoking superclass initialization
 
-But the first thing this method is to execute the ==initialize== method of its superclass, ==SimpleSwitchMorph==. The idea here is that any inherited state from the superclass will be properly initialized by the ==initialize== method of the superclass. It is ''always'' a good idea to initialize inherited state by sending ==super initialize== before doing anything else. We don't know exactly what ==SimpleSwitchMorph==’s ==initialize== method will do when we call it, ''and we don't care'', but it's a fair bet that it will set up some instance variables to hold reasonable default values that a ==SimpleSwitchMorph== is going to need. So we had better call it, or we risk our new object starting off in an invalid state.
+But the first thing this method does is to execute the ==initialize== method of its superclass, ==SimpleSwitchMorph==. The idea here is that any inherited state from the superclass will be properly initialized by the ==initialize== method of the superclass. It is ''always'' a good idea to initialize inherited state by sending a ==super initialize== before doing anything else. We don't know exactly what ==SimpleSwitchMorph==’s ==initialize== method will do when we call it, ''and we don't care'', but it's a fair bet that it will set up some instance variables to hold reasonable default values that a ==SimpleSwitchMorph== is going to need. So we had better call it, or we risk our new object starting off in an invalid state.
 
 The rest of the method sets up the state of this object. Sending ==self label: \''==, for example, sets the label of this object to the empty string.
 
@@ -99,11 +99,11 @@ The rest of the method sets up the state of this object. Sending ==self label: \
 
 The expression ==0@0 corner: 16@16== needs some explanation. ==0@0== constructs a ==Point== object with its ==x== and ==y== coordinates both set to 0. In fact, ==0@0== sends the message ==@== to the number ==0== with argument ==0==. The effect will be that the number ==0== will ask the ==Point== class to create a new instance with the coordinates ==(0,0)==. Now we send this newly created point the message ==corner: 16@16==, which causes it to create a ==Rectangle== with corners ==0@0== and ==16@16==. This newly created rectangle will be assigned to the ==bounds== variable, inherited from the superclass. And this ==bounds== variable determines how big our Morph is going to be - in effect we're just saying "be a 16 by 16 pixel square".
 
-Note that the origin of the Pharo screen is the top left, and the ==y== coordinate increases as we go down the screen.
+Note that the origin of the Pharo screen is at the top left, and the ==y== coordinate increases as we go down the screen.
 
 !!!!!About the rest
 
-The rest of the method should be self-explanatory. Part of the art of writing good Pharo code is to pick good method names so that the code can be read like (very basic) English. You should be able to imagine the object talking to itself and saying "Self, use square corners!", "Self, turn off!".
+The rest of the method should be self-explanatory. Part of the art of writing good Pharo code is picking good method names so that the code can be read like (very basic) English. You should be able to imagine the object talking to itself and saying "Self, use square corners!", "Self, turn off!".
 
 Notice that there is a little green arrow next to your method (see Figure *@fig:initialize*). This means the method exists in the superclass and is overridden in your class.
 
@@ -113,11 +113,11 @@ You can immediately test the effect of the code you have written by creating a n
 
 +The inspector used to examine a ==LOCell== object.>file://figures/inspectLOCell.png|width=80|label=fig:inspectLOCell+
 
-In the ""Raw"" tab of the Inspector The left-hand column shows a list of instance variables and the value of the instance variable is shown in the right column (see Figure *@fig:inspectLOCell*). Other tabs show other aspects of the ==LOCell==, take a look at them and experiment.
+In the ""Raw"" tab of the Inspector The left-hand column shows a list of instance variables, and the value of the instance variable is shown in the right column (see Figure *@fig:inspectLOCell*). Other tabs show other aspects of the ==LOCell==, take a look at them and experiment.
 
 +When we click on an instance variable, we inspect its value (another object).>file://figures/inspectBounds.png|width=80|label=fig:inspectBounds+
 
-If you click on an instance variable the Inspector will open a new pane with the detail of the instance variable (see Figure *@fig:inspectBounds*).
+If you click on an instance variable, the Inspector will open a new pane with the details of the instance variable (see Figure *@fig:inspectBounds*).
 
 +A ==LOCell== opened in the ""World"".>file://figures/LOCellOpenInWorld.png|width=80|label=fig:LOCellOpenInWorld+
 
@@ -129,7 +129,7 @@ Go to that Playground at the bottom of the pane and type the text ==self bounds:
 
 !!!!!The Morphic Halo
 
-The cell should appear near the top left-hand corner of the screen (as shown in Figure *@fig:LOCellOpenInWorld*) and exactly where its bounds say that it should appear - i.e. 200 pixels down from the top and 200 pixels in from the left. Meta-click (==Option-Shift-Click==) on the cell to bring up the ""Morphic Halo"". The Morphic halo represents a visual way to interact with a Morph, using the 'handles' that now surround the Morph. Move the cell with the brown handle (next to top-right) and resize it with the yellow handle (bottom-right). Notice how the bounds reported by the inspector also change (you may have to click refresh to see the new bounds value). Delete the cell by clicking on the ==x== in the pink handle.
+The cell should appear near the top left-hand corner of the screen (as shown in Figure *@fig:LOCellOpenInWorld*) and exactly where its bounds say that it should appear - i.e. 200 pixels down from the top and 200 pixels in from the left. Meta-click (==Option-Shift-Click==) on the cell to bring up the ""Morphic Halo"". The Morphic halo represents a visual way to interact with a Morph, using the 'handles' that now surround the Morph. Move the cell with the brown handle (next to the top-right) and resize it with the yellow handle (bottom-right). Notice how the bounds reported by the inspector also change (you may have to click refresh to see the new bounds value). Delete the cell by clicking on the ==x== in the pink handle.
 
 !!!Defining the class ==LOGame==
 
@@ -144,7 +144,7 @@ BorderedMorph subclass: #LOGame
 	package: 'PBE-LightsOut'
 ]]]
 
-Here we subclass ==BorderedMorph==. ==Morph== is the superclass of all of the graphical shapes in Pharo. We've already seen a ==SimpleSwitchMorph==, which is a ==Morph== that can be toggled on and off, and (unsurprisingly) a ==BorderedMorph== is a ==Morph== with a border. We could also insert the names of the instance variables between the quotes on the second line, but for now, let's just leave that list empty.
+Here, we subclass ==BorderedMorph==. ==Morph== is the superclass of all of the graphical shapes in Pharo. We've already seen a ==SimpleSwitchMorph==, which is a ==Morph== that can be toggled on and off, and (unsurprisingly) a ==BorderedMorph== is a ==Morph== with a border. We could also insert the names of the instance variables between the quotes on the second line, but for now, let's just leave that list empty.
 
 !!!Initializing our game
 
@@ -362,26 +362,26 @@ And now finally we are done!
 
 !!!!!About the Debugger
 
-By default when an error occurs in Pharo, the system displays a Debugger. However, we can fully control this behavior and make it do something else. For example, we can write the error to a file, or we can even serialize the execution stack to a file, zip and then reopen it in another Pharo image. When we are developing our software the Debugger is available to let us go as fast as possible. But in a production system developers will often want to control the Debugger to prevent their mistakes interfering too much with their users' work.
+By default, when an error occurs in Pharo, the system displays a Debugger. However, we can fully control this behavior and make it do something else. For example, we can write the error to a file, or we can even serialize the execution stack to a file, zip it and then reopen it in another Pharo image. When we are developing our software, the Debugger is available to let us go as fast as possible. But in a production system, developers will often want to control the Debugger to prevent their mistakes interfering too much with their users' work.
 
 !!!And if all else fails...
 
-First, do not stress! It's perfectly normal to make a mess of things when you program. If anything, it's the rule and not the exception. Probably the most annoying thing that can happen when you're starting to experiment with graphical elements in Pharo is the screen become cluttered with seemingly indestructible widgets. Don't panic. Try and get an Inspector up on one of them by using a meta-click (==Option-Shift-Click== or equivalent) to open the Morphic halo, select the menu handle, "debug > inspect". Once you get an Inspector open you're home free:
+First, do not stress! It's perfectly normal to make a mess of things when you program. If anything, it's the rule and not the exception. Probably the most annoying thing that can happen when you're starting to experiment with graphical elements in Pharo is that the screen becomes cluttered with seemingly indestructible widgets. Don't panic. Try and get an Inspector up on one of them by using a meta-click (==Option-Shift-Click== or equivalent) to open the Morphic halo, select the menu handle, "debug > inspect". Once you get an Inspector open you're home free:
 
 - if you are inspecting the game itself: ==self delete==.
 - if you are inspect a game cell: ==self owner delete==. 
 
 !!!Saving and sharing Pharo code
 
-Now that you have ""Lights Out"" working, you probably want to save it somewhere so that you can archive it and share it with your friends. Of course, you can save your whole Pharo image, and show off your first program by running it, but your friends probably have their own code in their images, and don't want to give that up to use your image. What you need is a way of getting source code out of your Pharo image so that other programmers can bring it into theirs.
+Now that you have ""Lights Out"" working, you probably want to save it somewhere so that you can archive it and share it with your friends. Of course, you can save your whole Pharo image and show off your first program by running it, but your friends probably have their own code in their images, and don't want to give that up to use your image. What you need is a way of getting the source code out of your Pharo image so that other programmers can bring it into theirs.
 
-We showed you the basics of using Iceberg and git to save, share and version your projects, and you should feel free to do that again with Lights Out. If you would like to learn more about Iceberg, and you're feeling impatient, then you should feel free to skip ahead to Chapter *@cha:Iceberg*.
+We showed you the basics of using Iceberg and Git to save, share, and version your projects, and you should feel free to do that again with Lights Out. If you would like to learn more about Iceberg, and you're feeling impatient, then you should feel free to skip ahead to Chapter *@cha:Iceberg*.
 
 If you're still reading this, we're now going to take a look at exporting your Pharo code as files.
 
 !!!Saving code in a file
 
-You can also save the code of your package by writing it to a file, an action commonly called "filing out" by all Pharoers, Squeakers and related communities. The right-click menu in the Package pane will give you the option to select ""Extra > File Out"" the whole of the ==PBE-LightsOut== package. The resulting file is more or less human readable, but is really intended for computers, not humans. You can email this file to your friends, and they can "file it in" to their own image.
+You can also save the code of your package by writing it to a file, an action commonly called "filing out" by all Pharoers, Squeakers and related communities. The right-click menu in the Package pane will give you the option to select ""Extra > File Out"" the whole of the ==PBE-LightsOut== package. The resulting file is more or less human readable, but is really intended for computers, not humans. You can email this file to your friends, and they can "file it in" with their own image.
 
 File out the ==PBE-LightsOut== package (see Figure *@fig:fileOut*). You should now find a file named ==PBE-LightsOut.st== in the same folder on disk where your image is saved. Have a look at this file with a text editor to get a feel for what the code looks like when it's in a file. If you don't want to leave Pharo to look at the file, try inspecting =='PBE-LightsOut.st' asFileReference'== in a Playground.
 
@@ -395,4 +395,4 @@ If you are used to getters and setters in other programming languages, you might
 
 !!!Chapter summary
 
-In this chapter we've had a chance to reinforce what we've learned about Pharo so far, and to apply it to writing a simple game using the Morphic framework. We've learned how to open the Morphic halo around graphical elements on the screen, how to manipulate them, and (importantly) how to get rid of them. We've also learned how to "file out" and "file in" Pharo packages for quick sharing.
+In this chapter, we've had a chance to reinforce what we've learned about Pharo so far, and to apply it to writing a simple game using the Morphic framework. We've learned how to open the Morphic halo around graphical elements on the screen, how to manipulate them, and (importantly) how to get rid of them. We've also learned how to "file out" and "file in" Pharo packages for quick sharing.

--- a/Chapters/IcebergIntro/FirstConfiguration.pillar
+++ b/Chapters/IcebergIntro/FirstConfiguration.pillar
@@ -1,10 +1,9 @@
 !!! Configure your project nicely
 @sec:Configure
 Versioning code is just the first part of making sure that you and others can reload your code.
-we describe how to define a baseline, a project map that you will use to define dependencies
-within your project and dependencies to other projects.
-We also show how to add a good ==.gitignore== file.
-In the next chapter we will show how to configure your project to get more out of the services offered within the Github ecosystem such as Github actions to execute automatically your tests.
+Here, we describe how to define a Baseline, a project map that you will use to define dependencies within your project and dependencies to other projects. We also show how to add a good ==.gitignore== file.
+
+In the next chapter, we will show how to configure your project to get more out of the services offered within the Github ecosystem, such as Github Actions to automatically execute your tests.
 
 We start by showing you how you can commit your code if you did not create your remote repository first.
 
@@ -12,21 +11,22 @@ We start by showing you how you can commit your code if you did not create your 
 
 !!! What if I did not create a remote repository
 
-In the previous chapter we started by creating a remote repository on Github.
-Then we asked Iceberg to add a project by cloning it from Github.
-Now you may ask yourself what is the process to publish first your project locally without a pre-existing repository. This is actually simple.
+In the previous chapter, we started by creating a remote repository on Github. Then we asked Iceberg to add a project by cloning it from Github. Now you may ask yourself what the process is to publish your project locally without a pre-existing repository. This is actually simple.
 
-!!!! Create a new repository.
+!!!! Create a new repository
+
 When you add a new repository use the 'New repository' option as shown in *@NewRepo*.
 
-!!!! Add a remote.
+!!!! Add a remote
+
 If you want to commit to a remote repository, you will have to add it using the ''Repository'' browser. 
 You can access this browser through the associated menu item or the icon.
-The ''Repository'' browser gives you access to the ==git== repositories associated with your project: you can access, manage branches and also add or remove remote repositories. 
+
+The ''Repository'' browser gives you access to the ==Git== repositories associated with your project: you can access, manage branches, and also add or remove remote repositories. 
+
 Figure *@OpeningRepositoryBrowser* shows the repository browser on our project.
 
 +Opening the repository browser let you add and browse branches as well as remote repositories.>file://figures/S13-OpeningRepository.png|width=75|label=OpeningRepositoryBrowser+
-
 
 Pressing on the 'Add remote' iconic button adds a remote by filling the needed information that you can find in your Github project. Figure *@OpeningRepositoryBrowser* shows it for the sample project using SSH and  Figure *@OpeningRepositoryBrowser2* for HTTPS.
 
@@ -34,7 +34,8 @@ Pressing on the 'Add remote' iconic button adds a remote by filling the needed i
 
 +Adding a remote using the ''Repository'' browser of your project (HTTP version).>file://figures/S14-AddingRemote-HTTP.png|width=75|label=OpeningRepositoryBrowser2+
 
-!!!! Push to the remote.
+!!!! Push to the remote
+
 Now you can push your changes and versions to the remote repository using the Push iconic button.
 Once you have pushed you can see that you have one remote as shown in Figure *@PushedFromReport*.
 
@@ -42,11 +43,9 @@ Once you have pushed you can see that you have one remote as shown in Figure *@P
 
 !!! Defining a ==BaselineOf==
 
-A ''baseline'' is a description of the architecture of a project.
-You will express the dependencies between your packages and other projects so that all the dependent projects are loaded without the user having to understand them or the links between them.
+A ''baseline'' is a description of the architecture of a project. You will express the dependencies between your packages and other projects so that all the dependent projects are loaded without the user having to understand them or the links between them.
 
-A baseline is expressed as a subclass of ==BaselineOf== and packaged in a package named =='BaselineOfXXX'== (where 'XXX' is the name of your project).
-So if you have no dependencies, you can have something like this.
+A baseline is expressed as a subclass of ==BaselineOf== and packaged in a package named =='BaselineOfXXX'== (where 'XXX' is the name of your project). So if you have no dependencies, you can have something like this:
 
 [[[
 BaselineOf subclass: #BaselineOfMyCoolProjectWithPharo
@@ -62,8 +61,7 @@ BaselineOfMyCoolProjectWithPharo >> baseline: spec
     do: [ spec package: 'MyCoolProjectWithPharo' ]
 ]]]
 
-Once you have defined your baseline, you should add its package to your project using the working copy browser as explained in the previous chapter. You should obtain the following situation shown in Figure *@WithBaseline*.
-Now, commit it and push your changes to your remote repository.
+Once you have defined your baseline, you should add its package to your project using the working copy browser as explained in the previous chapter. You should obtain the following situation shown in Figure *@WithBaseline*. Now, commit it and push your changes to your remote repository.
 
 +Added the baseline package to your project using the ''Working copy'' browser.>file://figures/WithBaseline.png|width=75|label=WithBaseline+
 
@@ -71,14 +69,17 @@ A more elaborated web resources about baseline possibility is available at: *htt
 
 
 !!! Loading from an existing repository
+
 Once you have a repository you committed code to and would like to load it into a new Pharo image, there are two ways to work this out.
 
-!!!! Manual load.
+!!!! Manual load
+
 - Add the project as explained in the first chapter
 - Open the working copy browser by double clicking on the project line in the repositories browser.
 - Select a package and manually load it.
 
-!!!! Scripting the load.
+!!!! Scripting the load
+
 The second way is to make use of Metacello. However, this will only work if you have already created a ==BaselineOf==. In this case, you can just execute the following snippet:
 
 [[[
@@ -90,7 +91,6 @@ Metacello new
 
 For projects with metadata, like the one we just created, that's it.
 Notice that we not only mention the Github pass but also added the code folder (here ==src==).
-
 
 !!! Going further:  Understanding the architecture
 

--- a/Chapters/IcebergIntro/StartedWithIceberg.pillar
+++ b/Chapters/IcebergIntro/StartedWithIceberg.pillar
@@ -5,7 +5,7 @@ In this chapter we will explain in more detail how you can publish your project 
 
 We will not explain basic concepts like commit, push/pull, merging, or cloning, please refer to a Git tutorial for this. A strong prerequisite for reading this chapter is that you must be able to publish from the command line to your Git hosting service. If you cannot, do not expect Iceberg to fix it for you. If you have some problems with your SSH configuration (which is the default way to push using GitHub) you can either use HTTPS instead, or read the ''Manage your code with Iceberg'' booklet that you can find on *http://books.pharo.org*. Let us get started.
 
-!!!For the impatient
+!!! For the impatient
 
 If you do not want to read through everything below, and you feel pretty confident, here is an executive summary of how to get your code published:
 

--- a/Chapters/Metaclasses/Metaclasses.pillar
+++ b/Chapters/Metaclasses/Metaclasses.pillar
@@ -1,24 +1,13 @@
 !!Classes and metaclasses
 @cha:metaclasses
 
-In Pharo, everything is an object, and every object is an instance of a class. Classes are no exception: classes are objects,
-and class objects are instances of other classes.  This model is lean, simple, elegant, and uniform.
-It fully captures the essence of object-oriented programming. 
-However, its implications of this uniformity may confuse newcomers.
+In Pharo, everything is an object, and every object is an instance of a class. Classes are no exception: classes are objects, and class objects are instances of other classes.  This model is lean, simple, elegant, and uniform. It fully captures the essence of object-oriented programming. However, the implications of this uniformity may confuse newcomers.
 
-Note that you do not need to fully understand the implications of this
-uniformity to program fluently in Pharo. Nevertheless, the goal of this chapter
-is twofold: (1) go as deep as possible and (2) show that there is nothing
-complex, ''magic'' or special here: just simple rules applied uniformly. By
-following these rules you can always understand why the situation is the way
-that it is.
+Note that you do not need to fully understand the implications of this uniformity to program fluently in Pharo. Nevertheless, the goal of this chapter is twofold: (1) go as deep as possible and (2) show that there is nothing complex, ''magic'' or special here: just simple rules applied uniformly. By following these rules, you can always understand why the situation is the way that it is.
 
 !!!Rules for classes
 
-The Pharo object model is based on a limited number of concepts applied
-uniformly. To refresh your memory, here are the rules of the object model that
-we explored in
-Chapter *: The Pharo Object Model>../PharoObjectModel/PharoObjectModel.pier@cha:model*.
+The Pharo object model is based on a limited number of concepts applied uniformly. To refresh your memory, here are the rules of the object model that we explored in Chapter *: The Pharo Object Model>../PharoObjectModel/PharoObjectModel.pier@cha:model*.
 
 ; Rule 1
 : Everything is an object.
@@ -34,22 +23,15 @@ Chapter *: The Pharo Object Model>../PharoObjectModel/PharoObjectModel.pier@cha:
 : Classes are objects too and follow exactly the same rules.
 
 A consequence of Rule 1 is that ''classes are objects too'', so Rule 2 tells us that classes must also be
-instances of classes.
-The class of a class is called a ''metaclass''.
+instances of classes. The class of a class is called a ''metaclass''.
 
 !!!Metaclasses
 @sec:metaclassIntro
 
-A metaclass is created automatically for you whenever you create a class. Most
-of the time you do not need to care or think about metaclasses. However, every
-time that you use the browser to browse the ''class side'' of a class, it is
-helpful to recall that you are actually browsing a different class. A class and
-its metaclass are two separate classes. 
-Indeed a point is different from the class ==Point== and this is the same for a class and its metaclass.
+A metaclass is created automatically for you whenever you create a class. Most of the time you do not need to care or think about metaclasses. However, every time that you use the browser to browse the ''class side'' of a class, it is helpful to recall that you are actually browsing a different class. A class and
+its metaclass are two separate classes. Indeed a point is different from the class ==Point== and this is the same for a class and its metaclass.
 
-To properly explain classes and metaclasses, we need to extend the rules from
-Chapter *: The Pharo Object Model>../PharoObjectModel/PharoObjectModel.pier@cha:model*
-with the following additional rules.
+To properly explain classes and metaclasses, we need to extend the rules from Chapter *: The Pharo Object Model>../PharoObjectModel/PharoObjectModel.pier@cha:model* with the following additional rules.
 
 ; Rule 7
 : Every class is an instance of a metaclass.
@@ -64,14 +46,11 @@ with the following additional rules.
 
 Together, these 11 simple rules complete Pharo's object model.
 
-We will first briefly revisit the 5 rules from
-Chapter *: The Pharo Object Model>../PharoObjectModel/PharoObjectModel.pier@cha:model*
-with a small example. Then we will take a closer look at the new rules, using
-the same example.
+We will first briefly revisit the 5 rules from Chapter *: The Pharo Object Model>../PharoObjectModel/PharoObjectModel.pier@cha:model* with a small example. Then we will take a closer look at the new rules, using the same example.
 
 +Sending the message ==class== to a sorted collection>file://figures/SortedCollectionClassMessage.png|label=fig:classmessage|width=99+
 
-!!!Revisiting the Pharo object model
+!!! Revisiting the Pharo object model
 
 ""Rule 1."" Since everything is an object, an ordered collection in Pharo is also an object.
 
@@ -80,18 +59,15 @@ OrderedCollection withAll: #(4 5 6 1 2 3)
 >>> an OrderedCollection(4 5 6 1 2 3)
 ]]]
 
-""Rule 2."" Every object is an instance of a class. An ordered collection is instance of the 
-the class ==OrderedCollection==:
+""Rule 2."" Every object is an instance of a class. An ordered collection is instance of the class ==OrderedCollection==:
 
 [[[testcase=true
 (OrderedCollection withAll: #(4 5 6 1 2 3)) class
 >>> OrderedCollection
 ]]]
 
-
 ""Rule 3."" Every class has a superclass. The superclass of ==OrderedCollection== is
-==SequenceableCollection== and the superclass of ==SequenceableCollection== is
-==Collection==:
+==SequenceableCollection== and the superclass of ==SequenceableCollection== is ==Collection==:
 
 [[[testcase=true
 OrderedCollection superclass
@@ -106,38 +82,22 @@ Collection superclass
 >>> Object
 ]]]
 
-""Rule 4."" Everything happens by sending messages, so we can deduce that
-==withAll:== is a message sent to ==OrderedCollection== and ==class== 
-are messages sent to the ordered collection instance, and
-==superclass== is a message sent to the class ==OrderedCollection== and
-==SequenceableCollection==, and ==Collection==.
-The receiver in each case is an object, since everything is an object, but some
-of these objects are also classes.
+""Rule 4."" Everything happens by sending messages, so we can deduce that ==withAll:== is a message sent to ==OrderedCollection== and ==class== are messages sent to the ordered collection instance, and ==superclass== is a message sent to the class ==OrderedCollection== and ==SequenceableCollection==, and ==Collection==.
+The receiver in each case is an object, since everything is an object, but some of these objects are also classes.
 
-""Rule 5."" Method lookup follows the inheritance chain, so when we send the
-message ==class== to the result of ==(OrderedCollection withAll: #(4 5 6 1 2 3))
-asSortedCollection==, the message is handled when the corresponding method is
-found in the class ==Object==, as shown in Figure *@fig:classmessage*.
+""Rule 5."" Method lookup follows the inheritance chain, so when we send the message ==class== to the result of ==(OrderedCollection withAll: #(4 5 6 1 2 3)) asSortedCollection==, the message is handled when the corresponding method is found in the class ==Object==, as shown in Figure *@fig:classmessage*.
 
 !!!Every class is an instance of a metaclass
 
-As we mentioned earlier in Section *@sec:metaclassIntro*, classes whose
-instances are themselves classes are ''called'' metaclasses.
-This is to make sure that we can precisely refer to the class ==Point== and the class of the class ==Point==.
+As we mentioned earlier in Section *@sec:metaclassIntro*, classes whose instances are themselves classes are ''called'' metaclasses. This is to make sure that we can precisely refer to the class ==Point== and the class of the class ==Point==.
 
 +The metaclasses of ==SortedCollection== and its superclasses (elided).>file://figures/SortedCollectionMetaclasses.png|label=fig:translucentmetaclasses+
 
 !!!!Metaclasses are implicit
 
-Metaclasses are automatically created when you define a class. We say that they
-are ''implicit'' since as a programmer you never have to worry about them. An
-implicit metaclass is created for each class you create, so each metaclass has
-only a single instance.
+Metaclasses are automatically created when you define a class. We say that they are ''implicit'' since as a programmer you never have to worry about them. An implicit metaclass is created for each class you create, so each metaclass has only a single instance.
 
-Whereas ordinary classes are named, metaclasses are anonymous. However, we can
-always refer to them through the class that is their instance. The class of
-==SortedCollection== is ==SortedCollection class==, and the class
-of ==Object== is ==Object class==:
+Whereas ordinary classes are named, metaclasses are anonymous. However, we can always refer to them through the class that is their instance. The class of ==SortedCollection== is ==SortedCollection class==, and the class of ==Object== is ==Object class==:
 
 [[[testcase=true
 SortedCollection class
@@ -148,8 +108,7 @@ Object class
 >>> Object class
 ]]]
 
-In fact metaclasses are not truly anonymous, their name is deduced from the one
-of their single instance.
+In fact metaclasses are not truly anonymous, their name is deduced from the one of their single instance.
 
 [[[testcase=true
 SortedCollection class name
@@ -161,39 +120,38 @@ Object class name
 >>> 'Object class'
 ]]]
 
-Figure *@fig:translucentmetaclasses* shows how each class is an instance of its
-metaclass. Note that we only skip ==SequenceableCollection==
-and ==Collection== from the figure and explanation due to space constraints.
+Figure *@fig:translucentmetaclasses* shows how each class is an instance of its metaclass. Note that we only skip ==SequenceableCollection== and ==Collection== from the figure and explanation due to space constraints.
 Their absence does not change the overall meaning.
-
-
-
 
 !!! Querying Metaclasses
 
-The fact that classes are also objects makes it easy for us to query them by
-sending messages. Let's have a look:
+The fact that classes are also objects makes it easy for us to query them by sending messages. Let's have a look:
 
 [[[testcase=true
 OrderedCollection subclasses
 >>> {SortedCollection . ObjectFinalizerCollection . WeakOrderedCollection . OCLiteralList . GLMMultiValue}
 ]]]
+
 [[[testcase=true
 SortedCollection subclasses
 >>> #()
 ]]]
+
 [[[
 SortedCollection allSuperclasses
 >>> an OrderedCollection(OrderedCollection SequenceableCollection Collection Object ProtoObject)
 ]]]
+
 [[[testcase=true
 SortedCollection instVarNames
 >>> #(#sortBlock)
 ]]]
+
 [[[testcase=true
 SortedCollection allInstVarNames
 >>> #(#array #firstIndex #lastIndex #sortBlock)
 ]]]
+
 [[[testcase=true
 SortedCollection selectors
 >>>  #(#sortBlock: #add: #groupedBy: #defaultSort:to: #addAll: #at:put: #copyEmpty #, #collect: #indexForInserting: #insert:before: #reSort #addFirst: #join: #median #flatCollect: #sort: #sort:to: #= #sortBlock)
@@ -203,127 +161,93 @@ SortedCollection selectors
 
 !!!The metaclass hierarchy parallels the class hierarchy
 
-Rule 7 says that the superclass of a metaclass cannot be an arbitrary class: it
-is constrained to be the metaclass of the superclass of the metaclass's unique
-instance: the metaclass of ==SortedCollection== inherits from the metaclass of ==OrderedCollection== (the superclass of ==SortedCollection==).
+Rule 7 says that the superclass of a metaclass cannot be an arbitrary class: it is constrained to be the metaclass of the superclass of the metaclass's unique instance: the metaclass of ==SortedCollection== inherits from the metaclass of ==OrderedCollection== (the superclass of ==SortedCollection==).
 
 [[[testcase=true
 SortedCollection class superclass
 >>> OrderedCollection class
 ]]]
+
 [[[testcase=true
 SortedCollection superclass class
 >>> OrderedCollection class
 ]]]
 
-This is what we mean by the metaclass hierarchy being parallel to the class
-hierarchy.
+This is what we mean by the metaclass hierarchy being parallel to the class hierarchy.
 Figure *@fig:parallelHierarchies* shows how this works in the ==SortedCollection== hierarchy.
-
-
 
 [[[testcase=true
 SortedCollection class
 >>> SortedCollection class
 ]]]
+
 [[[testcase=true
 SortedCollection class superclass
 >>> OrderedCollection class
 ]]]
+
 [[[testcase=true
 SortedCollection class superclass superclass
 >>> SequenceableCollection class
 ]]]
+
 [[[testcase=true
 SortedCollection class superclass superclass superclass superclass
 >>> Object class
 ]]]
 
-
 +Message lookup for classes is the same as for ordinary objects.>file://figures/InstanceMessage.png|label=fig:metaclasslookup|width=100+
 
 !!!Uniformity between Classes and Objects
 
-It is interesting to step back a moment and realize that there is no difference
-between sending a message to an object and to a class. In both cases the lookup
-for the corresponding method starts in the ''class of the receiver'', and
-''proceeds up the inheritance chain''.
+It is interesting to step back a moment and realize that there is no difference between sending a message to an object and to a class. In both cases the lookup for the corresponding method starts in the ''class of the receiver'', and ''proceeds up the inheritance chain''.
 
-Thus, messages sent to classes follow the metaclass inheritance chain.
-Consider, for example, the method ==withAll:==, which is implemented on the
-class side of ==Collection==. When we send the message ==withAll:== to the class
-==OrderedCollection==, then it is looked up the same way as any other message.
-The lookup starts in ==OrderedCollection class== (since it starts in the class
-of the receiver and the receiver is ==OrderedCollection==), and proceeds up the
-metaclass hierarchy until it is found in ==Collection class== (see Figure
-*@fig:metaclasslookup*). It returns a new instance of ==OrderedCollection==.
+Thus, messages sent to classes follow the metaclass inheritance chain. Consider, for example, the method ==withAll:==, which is implemented on the class side of ==Collection==. When we send the message ==withAll:== to the class ==OrderedCollection==, then it is looked up the same way as any other message. The lookup starts in ==OrderedCollection class== (since it starts in the class of the receiver and the receiver is ==OrderedCollection==), and proceeds up the metaclass hierarchy until it is found in ==Collection class== (see Figure *@fig:metaclasslookup*). It returns a new instance of ==OrderedCollection==.
 
 [[[testcase=true
 OrderedCollection withAll: #(4 5 6 1 2 3)
 >>> an OrderedCollection (4 5 6 1 2 3)
 ]]]
 
-
-
 !!!!Only one method lookup
-There is only one uniform kind of method lookup in Pharo.
-Classes are just objects, and behave like any other objects. Classes have the power to
-create new instances only because classes happen to respond to the message
-==new==, and because the ==new== method knows how to create new instances.
-Normally, non-class objects do not understand this message, but if you have a
-good reason to do so, there is nothing stopping you from adding a ==new== method
-to a non-metaclass.
+
+There is only one uniform kind of method lookup in Pharo. Classes are just objects, and behave like any other objects. Classes have the power to create new instances only because classes happen to respond to the message ==new==, and because the ==new== method knows how to create new instances.
+
+Normally, non-class objects do not understand this message, but if you have a good reason to do so, there is nothing stopping you from adding a ==new== method to a non-metaclass.
 
 +Classes are objects too.>file://figures/InspectingOrderedCollection.png|label=fig:inspectingColor+
 
 !!!Inspecting objects and classes
+
 Since classes are objects, we can also inspect them.
 
 Inspect ==OrderedCollection withAll: #(4 5 6 1 2 3)== and ==OrderedCollection==.
 
-Notice that in one case you are inspecting an instance of ==OrderedCollection==
-and in the other case the ==OrderedCollection== class itself. This can be a bit
-confusing, because the title bar of the inspector names the ''class'' of the
-object being inspected.
+Notice that in one case you are inspecting an instance of ==OrderedCollection== and in the other case the ==OrderedCollection== class itself. This can be a bit confusing, because the title bar of the inspector names the ''class'' of the object being inspected.
 
-The inspector on ==OrderedCollection== allows you to see the superclass,
-instance variables, method dictionary, and so on, of the ==OrderedCollection==
-class, as shown in Figure *@fig:inspectingColor*.
+The inspector on ==OrderedCollection== allows you to see the superclass, instance variables, method dictionary, and so on, of the ==OrderedCollection== class, as shown in Figure *@fig:inspectingColor*.
 
-!!!Every metaclass inherits from ==Class== and ==Behavior==
+!!! Every metaclass inherits from ==Class== and ==Behavior==
 
-Every metaclass is a kind of a class (a class with a single instance), hence
-inherits from ==Class==. ==Class== in turn inherits from its superclasses,
-==ClassDescription== and ==Behavior==. Since everything in Pharo is an object,
-these classes all inherit eventually from ==Object==. We can see the complete
-picture in Figure *@fig:inheritbehavior*.
+Every metaclass is a kind of a class (a class with a single instance), hence inherits from ==Class==. ==Class== in turn inherits from its superclasses, ==ClassDescription== and ==Behavior==. Since everything in Pharo is an object, these classes all inherit eventually from ==Object==. We can see the complete picture in Figure *@fig:inheritbehavior*.
 
 +Metaclasses inherit from ==Class== and ==Behavior==.>file://figures/SortedCollectionBehavior.png|label=fig:inheritbehavior+
 
-!!!!Where is ==new== defined?
+!!!! Where is ==new== defined?
 
-To understand the importance of the fact that metaclasses inherit from ==Class==
-and ==Behavior==, it helps to ask where ==new== is defined and how it is found.
+To understand the importance of the fact that metaclasses inherit from ==Class== and ==Behavior==, it helps to ask where ==new== is defined and how it is found.
 
-When the message ==new== is sent to a class, it is looked up in its metaclass
-chain and ultimately in its superclasses ==Class==, ==ClassDescription== and
-==Behavior== as shown in Figure *@fig:sendingnew*.
+When the message ==new== is sent to a class, it is looked up in its metaclass chain and ultimately in its superclasses ==Class==, ==ClassDescription== and ==Behavior== as shown in Figure *@fig:sendingnew*.
 
 When we send ==new== to the class ==SortedCollection==, the message is looked up in the metaclass ==SortedCollection class== and follows the inheritance chain. Remember it is the same lookup process than for any objects.
 
-The question ''Where is ==new== defined?'' is crucial. ==new== is first
-defined in the class ==Behavior==, and it can be redefined in its subclasses,
-including any of the metaclass of the classes we define, when this is necessary.
-Now when a message ==new== is sent to a class it is looked up, as usual, in the
-metaclass of this class, continuing up the superclass chain right up to the
-class ==Behavior==, if it has not been redefined along the way.
+The question ''Where is ==new== defined?'' is crucial. ==new== is first defined in the class ==Behavior==, and it can be redefined in its subclasses, including any of the metaclass of the classes we define, when this is necessary. 
 
-Note that the result of sending ==SortedCollection new== is an instance of
-==SortedCollection== and ''not'' of ==Behavior==, even though the method is
-looked up in the class ==Behavior==! 
-The method ==new== always returns an instance of
-==self==, the class that receives the message, even if it is implemented in
-another class.
+Now when a message ==new== is sent to a class it is looked up, as usual, in the metaclass of this class, continuing up the superclass chain right up to the class ==Behavior==, if it has not been redefined along the way.
+
+Note that the result of sending ==SortedCollection new== is an instance of ==SortedCollection== and ''not'' of ==Behavior==, even though the method is looked up in the class ==Behavior==! 
+
+The method ==new== always returns an instance of ==self==, the class that receives the message, even if it is implemented in another class.
 
 [[[testcase=true
 SortedCollection new class
@@ -332,93 +256,57 @@ SortedCollection new class
 
 +==new== is an ordinary message looked up in the metaclass chain.>file://figures/SortedOrderedSendingNew.png|label=fig:sendingnew+
 
-!!!!A common mistake
-A common mistake is to look for ==new== in the superclass of the receiving class. 
-The same holds for ==new:==, the standard message to create an object of
-a given size. For example, ==Array new: 4== creates an array of 4 elements. You
-will not find this method defined in ==Array== or any of its superclasses.
-Instead you should look in ==Array class== and its superclasses, since that is
-where the lookup will start (See Figure *@fig:sendingnew*).
+!!!! A common mistake
+
+A common mistake is to look for ==new== in the superclass of the receiving class. The same holds for ==new:==, the standard message to create an object of a given size. For example, ==Array new: 4== creates an array of 4 elements. You will not find this method defined in ==Array== or any of its superclasses.
+Instead you should look in ==Array class== and its superclasses, since that is where the lookup will start (See Figure *@fig:sendingnew*).
 
 The method ==new== and ==new:== are defined in metaclasses, because they are executed in response to messages sent to classes.
 
-In addition since a class is an object it can also be the receiver of messages whose methods are defined on ==Object==.
-When we send the message ==class== or ==error:== to the class ==Point==, the method lookup will go over the metaclass chain (looking in ==Point class==, ==Object class==....) up to ==Object==.
+In addition since a class is an object it can also be the receiver of messages whose methods are defined on ==Object==. When we send the message ==class== or ==error:== to the class ==Point==, the method lookup will go over the metaclass chain (looking in ==Point class==, ==Object class==....) up to ==Object==.
 
-!!!Responsibilities of ==Behavior==, ==ClassDescription==, and ==Class==
+!!! Responsibilities of ==Behavior==, ==ClassDescription==, and ==Class==
 
 !!!! ==Behavior==
-==Behavior== provides the minimum state necessary for objects that have
-instances, which includes a superclass link, a method dictionary and the class
-format. The class format is an integer that encodes the pointer/non-pointer
-distinction, compact/non-compact class distinction, and basic size of instances.
-==Behavior== inherits from ==Object==, so it, and all of its subclasses, can
-behave like objects.
 
-==Behavior== is also the basic interface to the compiler. It provides methods
-for creating a method dictionary, compiling methods, creating instances
-(''i.e.'', ==new==, ==basicNew==, ==new:==, and ==basicNew:==), manipulating the
-class hierarchy (''i.e.'', ==superclass:==, ==addSubclass:==), accessing
-methods (''i.e.'', ==selectors==, ==allSelectors==, ==compiledMethodAt:==),
-accessing instances and variables (''i.e.'', ==allInstances==,
-==instVarNames==...), accessing the class hierarchy (''i.e.'', ==superclass==,
-==subclasses==) and querying (''i.e.'', ==hasMethods==, ==includesSelector==,
+==Behavior== provides the minimum state necessary for objects that have instances, which includes a  superclass link, a method dictionary and the class format. The class format is an integer that encodes the pointer/non-pointer distinction, compact/non-compact class distinction, and basic size of instances.
+==Behavior== inherits from ==Object==, so it, and all of its subclasses, can behave like objects.
+
+==Behavior== is also the basic interface to the compiler. It provides methods for creating a method dictionary, compiling methods, creating instances (''i.e.'', ==new==, ==basicNew==, ==new:==, and ==basicNew:==), manipulating the class hierarchy (''i.e.'', ==superclass:==, ==addSubclass:==), accessing
+methods (''i.e.'', ==selectors==, ==allSelectors==, ==compiledMethodAt:==), accessing instances and variables (''i.e.'', ==allInstances==, ==instVarNames==...), accessing the class hierarchy (''i.e.'', ==superclass==, ==subclasses==) and querying (''i.e.'', ==hasMethods==, ==includesSelector==,
 ==canUnderstand:==, ==inheritsFrom:==, ==isVariable==).
 
 !!!! ==ClassDescription==
 
-==ClassDescription== is an abstract class that provides facilities needed by its
-two direct subclasses, ==Class== and ==Metaclass==. ==ClassDescription== adds a
-number of facilities to the base provided by ==Behavior==: named instance
-variables, the categorization of methods into protocols, the maintenance of
-change sets and the logging of changes, and most of the mechanisms needed for
-filing out changes.
+==ClassDescription== is an abstract class that provides facilities needed by its two direct subclasses, ==Class== and ==Metaclass==. ==ClassDescription== adds a number of facilities to the base provided by ==Behavior==: named instance variables, the categorization of methods into protocols, the maintenance of
+change sets and the logging of changes, and most of the mechanisms needed for filing out changes.
 
 !!!! ==Class==
 
-==Class== represents the common behaviour of all classes. It provides a class
-name, compilation methods, method storage, and instance variables. It provides a
-concrete representation for class variable names and shared pool variables
-(==addClassVarName:==, ==addSharedPool:==, ==initialize==). Since a metaclass is
-a class for its sole instance (''i.e.'', the non-meta class), all metaclasses
-ultimately inherit from ==Class== (as shown by Figure
-*@fig:metaclassclassclass*).
+==Class== represents the common behaviour of all classes. It provides a class name, compilation methods, method storage, and instance variables. It provides a concrete representation for class variable names and shared pool variables (==addClassVarName:==, ==addSharedPool:==, ==initialize==). Since a metaclass is
+a class for its sole instance (''i.e.'', the non-meta class), all metaclasses ultimately inherit from ==Class== (as shown by Figure *@fig:metaclassclassclass*).
 
-!!!Every metaclass is an instance of ==Metaclass==
+!!! Every metaclass is an instance of ==Metaclass==
 
-The next question is since metaclasses are objects too, they should be instances
-of another class, but which one? Metaclasses are objects too; they are instances
-of the class ==Metaclass== as shown in Figure *@fig:metaclassclass*. The
-instances of class ==Metaclass== are the anonymous metaclasses, each of which
+The next question is since metaclasses are objects too, they should be instances of another class, but which one? Metaclasses are objects too; they are instances of the class ==Metaclass== as shown in Figure *@fig:metaclassclass*. The instances of class ==Metaclass== are the anonymous metaclasses, each of which
 has exactly one instance, which is a class.
 
 +Every metaclass is a ==Metaclass==.>file://figures/SortedCollectionMetaclassClass.png|label=fig:metaclassclass+
 
-==Metaclass== represents common metaclass behaviour. It provides methods for
-instance creation (==subclassOf:==), creating initialized instances of the
-metaclass's sole instance, initialization of class variables, metaclass
-instance, method compilation, and class information (inheritance links,
+==Metaclass== represents common metaclass behaviour. It provides methods for instance creation (==subclassOf:==), creating initialized instances of the metaclass's sole instance, initialization of class variables, metaclass instance, method compilation, and class information (inheritance links,
 instance variables, ...).
 
 !!!The metaclass of ==Metaclass== is an instance of ==Metaclass==
 
-The final question to be answered is: what is the class of ==Metaclass class==?
-The answer is simple: it is a metaclass, so it must be an instance of
-==Metaclass==, just like all the other metaclasses in the system (see Figure
-*@fig:metaclassclassclass*).
+The final question to be answered is: what is the class of ==Metaclass class==? 
+
+The answer is simple: it is a metaclass, so it must be an instance of ==Metaclass==, just like all the other metaclasses in the system (see Figure *@fig:metaclassclassclass*).
 
 +All metaclasses are instances of the class ==Metaclass==, even the metaclass of ==Metaclass==.>file://figures/SortedCollectionMetaclassClassClass.png|label=fig:metaclassclassclass+
 
-Figure *@fig:metaclassclassclass* shows how all metaclasses are instances of
-==Metaclass==, including the metaclass of ==Metaclass== itself. If you compare
-Figures *@fig:metaclassclass* and *@fig:metaclassclassclass* you will see how
-the metaclass hierarchy perfectly mirrors the class hierarchy, all the way up to
-==Object class==.
+Figure *@fig:metaclassclassclass* shows how all metaclasses are instances of ==Metaclass==, including the metaclass of ==Metaclass== itself. If you compare Figures *@fig:metaclassclass* and *@fig:metaclassclassclass* you will see how the metaclass hierarchy perfectly mirrors the class hierarchy, all the way up to ==Object class==.
 
-The following examples show us how we can query the class hierarchy to
-demonstrate that Figure *@fig:metaclassclassclass* is correct. (Actually, you
-will see that we told a white lie — ==Object class superclass -\-> ProtoObject
-class==, not ==Class==. In Pharo, we must go one superclass higher
+The following examples show us how we can query the class hierarchy to demonstrate that Figure *@fig:metaclassclassclass* is correct. (Actually, you will see that we told a white lie — ==Object class superclass -\-> ProtoObject class==, not ==Class==. In Pharo, we must go one superclass higher
 to reach ==Class==.)
 
 [[[testcase=true
@@ -483,12 +371,8 @@ Metaclass superclass
 
 !!!Chapter summary
 
-This chapter gave an in-depth look into the uniform object model of Pharo, and a
-more thorough explanation of how classes are organized. If you get lost or
-confused, you should always remember that message passing is the key: ''you look
-for the method in the class of the receiver''. This works on ''any'' receiver. If
-the method is not found in the class of the receiver, it is looked up in its
-superclasses.
+This chapter gave an in-depth look into the uniform object model of Pharo, and a more thorough explanation of how classes are organized. If you get lost or confused, you should always remember that message passing is the key: ''you look for the method in the class of the receiver''. This works on ''any'' receiver. If
+the method is not found in the class of the receiver, it is looked up in its superclasses.
 
 -Every class is an instance of a metaclass. Metaclasses are implicit. A metaclass is created automatically when you create the class that is its sole instance. A metaclass is simply a class whose unique instance is a class.
 -The metaclass hierarchy parallels the class hierarchy. Method lookup for classes parallels method lookup for ordinary objects, and follows the metaclass's superclass chain.

--- a/Chapters/PharoObjectModel/PharoObjectModel.pillar
+++ b/Chapters/PharoObjectModel/PharoObjectModel.pillar
@@ -1,26 +1,14 @@
 !!The Pharo object model
 @cha:model
 
-The Pharo language model is inspired by the one of Smalltalk. It is
-simple and uniform: everything is an object, and objects communicate only by
-sending messages to each other. Instance variables are private to the object
-and methods are all public and dynamically looked up (late-bound). 
+The Pharo language model is inspired by the one of Smalltalk. It is simple and uniform: everything is an object, and objects communicate only by sending messages to each other. Instance variables are private to the object and methods are all public and dynamically looked up (late-bound). 
 
-In this chapter, we present the core concepts of the Pharo object model. 
-We sorted the sections of this chapter to make sure that the most important points appear first. 
-We revisit concepts such as ==self==, ==super== and precisely define their semantics. 
-Then we discuss the consequences of representing classes as objects. 
-This will be extended in Chapter:
-*Classes and Metaclasses>../Metaclasses/Metaclasses.pillar@cha:metaclasses*.
-
-
+In this chapter, we present the core concepts of the Pharo object model. We sorted the sections of this chapter to make sure that the most important points appear first. We revisit concepts such as ==self==, ==super== and precisely define their semantics. Then we discuss the consequences of representing classes as objects. This will be extended in Chapter: *Classes and Metaclasses>../Metaclasses/Metaclasses.pillar@cha:metaclasses*.
 
 !!!The rules of the core model
 @sec:rules
 
-The object model is based on a set of simple rules that are applied ''uniformly'' and systematically without any exception.
-The rules are as follows:
-
+The object model is based on a set of simple rules that are applied ''uniformly'' and systematically without any exception. The rules are as follows:
 
 ; Rule 1
 : Everything is an object.
@@ -39,12 +27,7 @@ Let us look at each of these rules in detail.
 
 !!!Everything is an Object
 
-The mantra ''everything is an object'' is highly contagious. After only a short
-while working with Pharo, you will become surprised how this rule
-simplifies everything you do. Integers, for example, are objects too, so you
-send messages to them, just as you do to any other object. At the end of
-this chapter, we added an implementation note on the object implementation for
-the curious reader.
+The mantra ''everything is an object'' is highly contagious. After only a short while working with Pharo, you will become surprised how this rule simplifies everything you do. Integers, for example, are objects too, so you send messages to them, just as you do to any other object. At the end of this chapter, we added an implementation note on the object implementation for the curious reader.
 
 Here are two examples.
 
@@ -58,17 +41,11 @@ Here are two examples.
 >>> 2432902008176640000
 ]]]
 
-The object ==7== is different than the object returned by ==20 factorial==. 
-==7== is an instance of ==SmallInteger== while ==20 factorial== is an instance of ==LargePositiveInteger==. 
-But because they are both polymorphic objects (they know how to answer to the same set of messages), none of the code, not even the implementation of ==factorial==, needs to know about this.
+The object ==7== is different than the object returned by ==20 factorial==. ==7== is an instance of ==SmallInteger== while ==20 factorial== is an instance of ==LargePositiveInteger==. But because they are both polymorphic objects (they know how to answer to the same set of messages), none of the code, not even the implementation of ==factorial==, needs to know about this.
 
-Coming back to ''everything is an object'' rule, perhaps the most fundamental
-consequence of this rule is that classes are objects too. Classes are not
-second-class objects: they are really first-class objects that you can send
-messages to, inspect, and change as any object.
+Coming back to ''everything is an object'' rule, perhaps the most fundamental consequence of this rule is that classes are objects too. Classes are not second-class objects: they are really first-class objects that you can send messages to, inspect, and change as any object.
 
-From the point of view of sending a message, there is no difference between an instance such as ==7== and a class.
-The following example shows that we can send the message ==today== to the class ==Date== to obtain the current date of the system.
+From the point of view of sending a message, there is no difference between an instance such as ==7== and a class. The following example shows that we can send the message ==today== to the class ==Date== to obtain the current date of the system.
 
 [[[example=true|caption=Sending ==today== to class ==Date== yields the current date
 Date today printString
@@ -115,48 +92,29 @@ Object new class
 >>> Object
 ]]]
 
-A class defines the ''structure'' of its instances via instance variables, and
-the ''behavior'' of its instances via methods. Each method has a name, called
-its ''selector'', which is unique within the class.
+A class defines the ''structure'' of its instances via instance variables, and the ''behavior'' of its instances via methods. Each method has a name, called its ''selector'', which is unique within the class.
 
-Since ''classes are objects'', and ''every object is an instance of a class'',
-it follows that classes must also be instances of classes. A class whose
-instances are classes is called a ''metaclass''. Whenever you create a class,
-the system automatically creates a metaclass for you. The metaclass defines the
-structure and behavior of the class that is its instance. You will not need to
-think about metaclasses 99\% of the time, and may happily ignore them. 
-We will have a closer look at metaclasses in Chapter
+Since ''classes are objects'', and ''every object is an instance of a class'', it follows that classes must also be instances of classes. A class whose instances are classes is called a ''metaclass''. Whenever you create a class, the system automatically creates a metaclass for you. The metaclass defines the structure and behavior of the class that is its instance. You will not need to think about metaclasses 99\% of the time, and may happily ignore them. We will have a closer look at metaclasses in Chapter
 *: Classes and Metaclasses>../Metaclasses/Metaclasses.pillar@cha:metaclasses*.
 
 !!! Instance structure and behavior
-Now we will briefly present how we specify the structure and behavior of
-instances.
+
+Now we will briefly present how we specify the structure and behavior of instances.
 
 !!!!Instance variables
-Instance variables are accessed by name in any of the instance methods of the
-class that defines them, and also in the methods defined in its subclasses.
-This means that Pharo instance variables are similar to ''protected'' variables in
-C\+\+ and Java.
-However, we prefer to say that they are private, because it is considered bad style in Pharo to access an instance variable directly from a subclass.
+
+Instance variables are accessed by name in any of the instance methods of the class that defines them, and also in the methods defined in its subclasses. This means that Pharo instance variables are similar to ''protected'' variables in C\+\+ and Java. However, we prefer to say that they are private, because it is considered bad style in Pharo to access an instance variable directly from a subclass.
 
 !!!!Instance-based encapsulation
-Instance variables in Pharo are private to the ''instance'' itself.
-This is in contrast to Java and C\+\+, which let instance variables (also known as ''fields'' or ''member variables'') to be accessed by any other instance that happens to be of the same class.
-We say that the ''encapsulation boundary'' of objects in Java and C\+\+ is the class, whereas in Pharo it is the instance.
 
-In Pharo, two instances of the same class cannot access each other's instance
-variables unless the class defines ''accessor methods''.
-There is no language syntax that provides direct access to the instance variables of any other
-object.
-Actually, a mechanism called reflection provides a way to ask another object for the values of its instance variables.
-Reflection is at the root of meta-programming which is used for writing tools like the object inspector.
+Instance variables in Pharo are private to the ''instance'' itself. This is in contrast to Java and C\+\+, which let instance variables (also known as ''fields'' or ''member variables'') to be accessed by any other instance that happens to be of the same class. We say that the ''encapsulation boundary'' of objects in Java and C\+\+ is the class, whereas in Pharo it is the instance.
+
+In Pharo, two instances of the same class cannot access each other's instance variables unless the class defines ''accessor methods''. There is no language syntax that provides direct access to the instance variables of any other object. Actually, a mechanism called reflection provides a way to ask another object for the values of its instance variables. Reflection is at the root of meta-programming which is used for writing tools like the object inspector.
 
 !!!!Instance encapsulation example
 
 The method ==distanceTo:== of the class ==Point== computes the distance between the receiver and
-another point.
-The instance variables ==x== and ==y== of the receiver are accessed directly by the method body.
-However, the instance variables of the other point must be accessed by sending it the messages ==x== and ==y==.
+another point. The instance variables ==x== and ==y== of the receiver are accessed directly by the method body. However, the instance variables of the other point must be accessed by sending it the messages ==x== and ==y==.
 
 [[[label=scr:distance|caption=Distance between two points.
 Point >> distanceTo: aPoint
@@ -184,35 +142,17 @@ record in a database, or on another computer in a distributed system.
 As long as it can respond to the messages ==x== and ==y==, the code of method ==distanceTo:==
 (shown above) will still work.
 
-
-
-
-
-
-
-
 !!!!Methods
 
-All methods are ''public'' and ''virtual'' (i.e., dynamically looked up).
-There is no static methods in Pharo. 
-Methods can access all instance variables of the object.
-Some developers prefer to access instance variables only through accessors.
-This practice has some value, but it also clutters the interface of your classes, and worse, exposes
-its private state to the world.
+All methods are ''public'' and ''virtual'' (i.e., dynamically looked up). There is no static methods in Pharo. Methods can access all instance variables of the object. Some developers prefer to access instance variables only through accessors. This practice has some value, but it also clutters the interface of your classes, and worse, exposes its private state to the world.
 
-To ease class browsing, methods are grouped into ''protocols'' that indicate their intent. 
-Protocols have no semantics from the language view point.
-They are just folders in which methods are stored.
-Some common protocol names have been established by convention, for example, ==accessing== for all
-accessor methods and ==initialization== for establishing a consistent initial state for the object.
-The protocol ==private== is sometimes used to group methods that should not be relied on.
-Nothing, however, prevents you from sending a message that is implemented by such a "private" method.
-However, it means that the developer may change or remove such private method.
+To ease class browsing, methods are grouped into ''protocols'' that indicate their intent. Protocols have no semantics from the language view point. They are just folders in which methods are stored. Some common protocol names have been established by convention, for example, ==accessing== for all accessor methods and ==initialization== for establishing a consistent initial state for the object.
+
+The protocol ==private== is sometimes used to group methods that should not be relied on. Nothing, however, prevents you from sending a message that is implemented by such a "private" method. However, it means that the developer may change or remove such private method.
 
 !!!Every class has a superclass
 
-Each class in Pharo inherits its behaviour and the description of its structure from a single ''superclass''. 
-This means that Pharo offers single inheritance.
+Each class in Pharo inherits its behaviour and the description of its structure from a single ''superclass''. This means that Pharo offers single inheritance.
 
 Here are some examples showing how can we navigate the hierarchy.
 
@@ -253,9 +193,7 @@ In Pharo, the root of the inheritance tree is actually the class ==ProtoObject==
 The class ==ProtoObject== encapsulates the minimal set of messages that all objects ''must'' have and ==ProtoObject== is designed to raise as many as possible errors (to support proxy definition). 
 Unless you have a very good reason to do otherwise, when creating application classes you should normally subclass ==Object==, or one of its subclasses.
 
-A new class is normally created by sending the message ==subclass: instanceVariableNames: ...== to an existing class as shown in *@scr:point*.
-There are a few other methods to create classes. 
-To see what they are, have a look at ==Class== and its ==subclass creation== protocol.
+A new class is normally created by sending the message ==subclass: instanceVariableNames: ...== to an existing class as shown in *@scr:point*. There are a few other methods to create classes. To see what they are, have a look at ==Class== and its ==subclass creation== protocol.
 
 [[[label=scr:point|caption=The definition of the class ==Point==.
 Object subclass: #Point
@@ -288,17 +226,17 @@ Since different objects may have different methods for responding to the same me
 >>> 5@6
 ]]]
 
-As a consequence, we can send the ''same message'' to different objects, each of
-which may have ''its own method'' for responding to the message.
+As a consequence, we can send the ''same message'' to different objects, each of which may have ''its own method'' for responding to the message.
 
 In the previous examples, we do not decide how the ==SmallInteger== ==3== or the ==Point== ==(1@2)== should respond to the message ==\+ 4==. We let the objet decide: Each has its own method for ==\+==, and responds to ==\+ 4== accordingly.
 
-!!!! Vocabulary point. 
+!!!! Vocabulary point
+
 In Pharo, we do ''not''  say that we "invoke methods". Instead, we ''send messages.'' 
 This is just a vocabulary point but it is significant. It implies that this is not the responsibility of the client to select the method to be executed, it is the one of the receiver of the message.
 
+!!!! About other computation
 
-!!!! About other computation.
 ''Nearly'' everything in Pharo happens by sending messages.
 At some point action must take place:
 
@@ -310,34 +248,26 @@ At some point action must take place:
 
 Other than these few exceptions, pretty much everything else does truly happen by sending messages.
 
-
 !!!! About object-oriented programming.
-One of the consequences of Pharo's model of message sending is that it
-encourages a style in which objects tend to have very small methods and delegate
-tasks to other objects, rather than implementing huge, procedural methods that
-assume too much responsibility.
+
+One of the consequences of Pharo's model of message sending is that it encourages a style in which objects tend to have very small methods and delegate tasks to other objects, rather than implementing huge, procedural methods that assume too much responsibility.
 
 Joseph Pelrine expresses this principle succinctly as follows:
 
 @@note Don't do anything that you can push off onto someone else.
 
-Many object-oriented languages provide both static and dynamic operations for
-objects. In Pharo there are only dynamic message sends. For example, instead of
-providing static class operations, we simply send messages to classes (which
-are simply objects).
+Many object-oriented languages provide both static and dynamic operations for objects. In Pharo there are only dynamic message sends. For example, instead of providing static class operations, we simply send messages to classes (which are simply objects).
 
-In particular, since there are no ''public fields'' in Pharo, the only way to update an instance variable of another object is to send it a message asking that it update its own field. 
-Of course, providing setter and getter methods for all the instance variables of an object is not good object-oriented style, because clients can access to the internal state of objects.
+In particular, since there are no ''public fields'' in Pharo, the only way to update an instance variable of another object is to send it a message asking that it update its own field. Of course, providing setter and getter methods for all the instance variables of an object is not good object-oriented style, because clients can access to the internal state of objects.
 
 Joseph Pelrine also states this very nicely:
 
 @@note Don't let anyone else play with your data.
 
-
-
 !!!Sending a message: a two-step process 
 
 What exactly happens when an object receives a message?
+
 This is a two-step process: ''method lookup'' and ''method execution''.
 
 - ""Lookup."" First, the method having the same name as the message is looked up.
@@ -354,12 +284,9 @@ Nevertheless there are a few questions that need some care to answer:
 - ''What is the difference between ==self== and ==super== sends?''
 - ''What happens when no method is found?''
 
-The rules for method lookup that we present here are conceptual; virtual machine
-implementors use all kinds of tricks and optimizations to speed up method
-lookup.
+The rules for method lookup that we present here are conceptual; virtual machine implementors use all kinds of tricks and optimizations to speed up method lookup.
 
-First let us look at the basic lookup strategy, and then consider these further
-questions.
+First let us look at the basic lookup strategy, and then consider these further questions.
 
 !!!Method lookup follows the inheritance chain
 
@@ -369,16 +296,14 @@ Suppose we create an instance of ==EllipseMorph==.
 anEllipse := EllipseMorph new.
 ]]]
 
-If we send the message ==defaultColor== to this object now, we get the result
-==Color yellow==.
+If we send the message ==defaultColor== to this object now, we get the result ==Color yellow==.
 
 [[[testcase=true
 anEllipse defaultColor
 >>> Color yellow
 ]]]
 
-The class ==EllipseMorph== implements ==defaultColor==, so the appropriate
-method is found immediately.
+The class ==EllipseMorph== implements ==defaultColor==, so the appropriate method is found immediately.
 
 [[[label=scr:defaultColor|caption=A locally implemented method.
 EllipseMorph >> defaultColor
@@ -386,11 +311,7 @@ EllipseMorph >> defaultColor
      ^ Color yellow
 ]]]
 
-In contrast, if we send the message ==openInWorld== to ==anEllipse==, the method
-is not immediately found, since the class ==EllipseMorph== does not implement
-==openInWorld==. The search therefore continues in the superclass,
-==BorderedMorph==, and so on, until an ==openInWorld== method is found in the
-class ==Morph== (see Figure *@fig:openInWorldLookup*).
+In contrast, if we send the message ==openInWorld== to ==anEllipse==, the method is not immediately found, since the class ==EllipseMorph== does not implement ==openInWorld==. The search therefore continues in the superclass, ==BorderedMorph==, and so on, until an ==openInWorld== method is found in the class ==Morph== (see Figure *@fig:openInWorldLookup*).
 
 [[[label=scr:openInWorld|caption=An inherited method.
 Morph >> openInWorld
@@ -400,18 +321,16 @@ Morph >> openInWorld
 
 +Method lookup follows the inheritance hierarchy.>file://figures/openInWorldLookup.png|width=80|label=fig:openInWorldLookup+
 
-
-
 !!!Method execution
+
 We mentioned that sending a message is a two-step process:
+
 - ""Lookup."" First, the method having the same name as the message is looked up.
 - ""Method Execution."" Second, the found method is applied to the receiver with the message arguments: When the method is found, the arguments are bound to the parameters of the method, and the virtual machine executes it.
 
 Now we explain the second point: the method execution.
 
-When the lookup returns a method, the receiver of the message is bound to ==self==, and the arguments of the message to the method parameters. Then the system executes the method body. 
-This is true wherever the method that should be executed is found. 
-Imagine that we send the message ==EllipseMorph new closestPointTo: 100@100== and that the method is defined as in Listing *@scr:closestPoing*. 
+When the lookup returns a method, the receiver of the message is bound to ==self==, and the arguments of the message to the method parameters. Then the system executes the method body. This is true wherever the method that should be executed is found. Imagine that we send the message ==EllipseMorph new closestPointTo: 100@100== and that the method is defined as in Listing *@scr:closestPoing*. 
 
 [[[label=scr:closestPoing|caption=Another locally implemented method.
 EllipseMorph >> closestPointTo: aPoint
@@ -432,15 +351,13 @@ This is why there are two different steps during a message send: looking up the 
 
 What happens if the method we are looking for is not found?
 
-Suppose we send the message ==foo== to our ellipse.
-First the normal method lookup will go through the inheritance chain all the way up to ==Object== (or rather ==ProtoObject==) looking for this method.
+Suppose we send the message ==foo== to our ellipse. First the normal method lookup will go through the inheritance chain all the way up to ==Object== (or rather ==ProtoObject==) looking for this method.
 When this method is not found, the virtual machine will cause the object to send ==self doesNotUnderstand: #foo== (See Figure *@fig:fooNotFound*).
 
 +Message ==foo== is not understood.>file://figures/fooNotFound.png|label=fig:fooNotFound|width=95+
 
 Now, this is a perfectly ordinary, dynamic message send, so the lookup starts again from the class ==EllipseMorph==, but this time searching for the method ==doesNotUnderstand:==. 
-As it turns out, ==Object== implements ==doesNotUnderstand:==. 
-This method will create a new ==MessageNotUnderstood== object which is capable of starting a Debugger in the current execution context.
+As it turns out, ==Object== implements ==doesNotUnderstand:==. This method will create a new ==MessageNotUnderstood== object which is capable of starting a Debugger in the current execution context.
 
 Why do we take this convoluted path to handle such an obvious error?
 Well, this offers developers an easy way to intercept such errors and take alternative action.
@@ -449,19 +366,13 @@ One could easily override the method ==Object>>doesNotUnderstand:== in any subcl
 In fact, this can be an easy way to implement automatic delegation of messages from one object to another. 
 A delegating object could simply delegate all messages it does not understand to another object whose responsibility it is to handle them, or raise an error itself!
 
-
 !!!About returning self
 
 Notice that the method ==defaultColor== of the class ==EllipseMorph== explicitly returns ==Color yellow==,
 whereas the method ==openInWorld== of ==Morph== does not appear to return anything.
 
-Actually a method ''always'' answers a message with a value (which is, of
-course, an object). 
-The answer may be defined by the ==^== construct in the method, but if execution reaches the end of the method without executing a
-==^==, the method still answers a value \-\- it answers the object that received the message. 
-We usually say that the method ''answers self'', because in Pharo the pseudo-variable ==self== represents the receiver of the message, much like the keyword ==this== in Java. 
-Other languages, such as Ruby, by default return the value of the last statement in the method. 
-Again, this is not the case in Pharo, instead you can imagine that a method without an explicit return ends with ==^ self==.
+Actually a method ''always'' answers a message with a value (which is, of course, an object). The answer may be defined by the ==^== construct in the method, but if execution reaches the end of the method without executing a ==^==, the method still answers a value \-\- it answers the object that received the message. 
+We usually say that the method ''answers self'', because in Pharo the pseudo-variable ==self== represents the receiver of the message, much like the keyword ==this== in Java. Other languages, such as Ruby, by default return the value of the last statement in the method. Again, this is not the case in Pharo, instead you can imagine that a method without an explicit return ends with ==^ self==.
 
 @@important ==self== always represents the receiver of the message. 
 
@@ -475,11 +386,8 @@ Morph >> openInWorld
 ]]]
 
 Why is explicitly writing ==^ self== not a so good thing to do? 
-When you return something explicitly, you are communicating that you are returning
-something of interest to the sender. 
-When you explicitly return ==self==, you are saying that you expect the sender to use the returned value.
-This is not the case here, so it is best not to explicitly return ==self==.
-We only return ==self== on special case to stress that the receiver is returned.
+
+When you return something explicitly, you are communicating that you are returning something of interest to the sender. When you explicitly return ==self==, you are saying that you expect the sender to use the returned value. This is not the case here, so it is best not to explicitly return ==self==. We only return ==self== on special case to stress that the receiver is returned.
 
 This is a common idiom in Pharo, which Kent Beck refers to as ''Interesting return value'': ''"Return a value only when you intend for the sender to use the value."''
 
@@ -493,14 +401,9 @@ In fact, if we open a new morph (==Morph new openInWorld==) we see that we get a
 We say that ==EllipseMorph== ''overrides'' the ==defaultColor== method that it inherits from ==Morph==. 
 The inherited method no longer exists from the point of view of ==anEllipse==.
 
-Sometimes we do not want to override inherited methods, but rather ''extend'' them with some new functionality, that is, we would like to be able to invoke
-the overridden method ''in addition to'' the new functionality we are defining in the subclass. 
-In Pharo, as in many object-oriented languages that support single inheritance, this can be done with the help of ==super== sends.
+Sometimes we do not want to override inherited methods, but rather ''extend'' them with some new functionality, that is, we would like to be able to invoke the overridden method ''in addition to'' the new functionality we are defining in the subclass. In Pharo, as in many object-oriented languages that support single inheritance, this can be done with the help of ==super== sends.
 
-A frequent application of this mechanism is in the ==initialize== method.
-Whenever a new instance of a class is initialized, it is critical to also initialize any inherited instance variables.
-However, the knowledge of how to do this is already captured in the ==initialize== methods of each of the superclass in the inheritance chain.
-The subclass has no business even trying to initialize inherited instance variables!
+A frequent application of this mechanism is in the ==initialize== method. Whenever a new instance of a class is initialized, it is critical to also initialize any inherited instance variables. However, the knowledge of how to do this is already captured in the ==initialize== methods of each of the superclass in the inheritance chain. The subclass has no business even trying to initialize inherited instance variables!
 
 It is therefore good practice whenever implementing an ==initialize== method to send ==super initialize== before performing any further initialization as shown in Listing *@scr:morphinit*.
 
@@ -518,10 +421,7 @@ We need ==super== sends to compose inherited behaviour that would otherwise be o
 
 !!!Self and super sends
 
-==self== represents the receiver of the message and the lookup of the method
-starts in the class of the receiver. Now what is ==super==? ==super== is ''not'' the superclass!
-It is a common and natural mistake to think this.
-It is also a mistake to think that lookup starts in the superclass of the class of the receiver.
+==self== represents the receiver of the message and the lookup of the method starts in the class of the receiver. Now what is ==super==? ==super== is ''not'' the superclass! It is a common and natural mistake to think this. It is also a mistake to think that lookup starts in the superclass of the class of the receiver.
 
 @@important ==self== represents the receiver of the message and the method lookup starts in the class of the receiver.
 
@@ -594,54 +494,38 @@ We then immediately find and execute the method ==fullPrintOn:== of the class ==
 
 !!! Stepping back
 
-A ==self== send is dynamic in the sense that by looking at the method containing
-it, we cannot predict which method will be executed. 
-Indeed an instance of a subclass may receive the message containing the self expression and redefine the
-method in that subclass. 
-Here ==EllipseMorph== could redefine the method ==fullPrintOn:== and this method would be executed by method ==constructorString==. 
-Note that by only looking at the method ==constructorString==, we cannot predict which ==fullPrintOn:== method (either the one of ==EllipseMorph==, ==BorderedMorph==, or ==Morph==) will be executed
-when executing the method ==constructorString==, since it depends on the receiver the ==constructorString== message.
+A ==self== send is dynamic in the sense that by looking at the method containing it, we cannot predict which method will be executed. Indeed an instance of a subclass may receive the message containing the self expression and redefine the method in that subclass. Here ==EllipseMorph== could redefine the method ==fullPrintOn:== and this method would be executed by method ==constructorString==. Note that by only looking at the method ==constructorString==, we cannot predict which ==fullPrintOn:== method (either the one of ==EllipseMorph==, ==BorderedMorph==, or ==Morph==) will be executed when executing the method ==constructorString==, since it depends on the receiver the ==constructorString== message.
 
 @@important A ==self== send triggers a ''method lookup starting in the class of the receiver.'' A ==self== send is dynamic in the sense that by looking at the method containing it, we cannot predict which method will be executed.
 
 Note that the ==super== lookup did not start in the superclass of the receiver.
-This would have caused lookup to start from ==BorderedMorph==, resulting in an
-infinite loop!
+This would have caused lookup to start from ==BorderedMorph==, resulting in an infinite loop!
 
-If you think carefully about ==super== send and Figure *@fig:constructorStringLookup*, you will realize that ==super== bindings are static: all that matters is the class in which the text of the ==super== send is found. 
-By contrast, the meaning of ==self== is dynamic: it always represents the receiver of the currently executing message. This means that ''all'' messages sent to ==self== are looked up by starting in the receiver's class.
+If you think carefully about ==super== send and Figure *@fig:constructorStringLookup*, you will realize that ==super== bindings are static: all that matters is the class in which the text of the ==super== send is found. By contrast, the meaning of ==self== is dynamic: it always represents the receiver of the currently executing message. This means that ''all'' messages sent to ==self== are looked up by starting in the receiver's class.
 
 @@important A ==super== send triggers a method lookup starting in the ''superclass of the class of the method performing the ==super== send''. We say that super sends are ''static'' because just looking at the method we know the class where the lookup should start (the class above the class containing the method).
 
-
 !!!The instance and class sides
 
-Since classes are objects, they have their own instance variables and their
-own methods. 
-We call these ''class instance variables'' and ''class methods'', but they are really no different from ordinary instance variables and methods:
-They simply operate on different objects (classes in this case). 
+Since classes are objects, they have their own instance variables and their own methods. We call these ''class instance variables'' and ''class methods'', but they are really no different from ordinary instance variables and methods: They simply operate on different objects (classes in this case). 
+
 An instance variable describes instance state and a method describes instance behavior.
-Similarly, class instance variables are just instance variables defined by a
-metaclass (a class whose instances are classes):
+
+Similarly, class instance variables are just instance variables defined by a metaclass (a class whose instances are classes):
 - ''Class instance variables'' describe the state of classes. An example is the superclass instance variable that describes the superclass of a given class.
 - ''Class methods'' are just methods defined by a metaclass and that will be executed on classes. Sending the message ==now== to the class ==Date== is defined on the (meta)class ==Date class==. This method is executed with the class ==Date== as receiver.
-
 
 A class and its metaclass are two separate classes, even though the former is an instance of the latter. 
 However, this is largely irrelevant to you as a programmer: you are concerned with defining the behavior of your objects and the classes that create them.
 
 +Browsing a class and its metaclass.>file://figures/colorInstanceClassSide.png|label=fig:colorInstanceClassSide|width=90+
 
-For this reason, the browser helps you to browse both class and metaclass as if
-they were a single thing with two "sides": the ''instance side'' and the ''class
-side'', as shown in Figure *@fig:colorInstanceClassSide*. 
+For this reason, the browser helps you to browse both class and metaclass as if they were a single thing with two "sides": the ''instance side'' and the ''class side'', as shown in Figure *@fig:colorInstanceClassSide*. 
 
 - By default, when you select a class in the browser, you're browsing the ''instance side'' i.e., the methods that are executed when messages are sent to an ''instance'' of ==Color==. 
 - Clicking on the ""Class side"" button switches you over to the ''class side'': the methods that will be executed when messages are sent to the ''class'' ==Color== itself.
 
-For example, ==Color blue== sends the message ==blue== to the class ==Color==.
-You will therefore find the method ==blue== defined on the ''class side'' of
-==Color==, not on the instance side.
+For example, ==Color blue== sends the message ==blue== to the class ==Color==. You will therefore find the method ==blue== defined on the ''class side'' of ==Color==, not on the instance side.
 
 [[[example=true|caption=The class method ==blue== (defined on the class-side).
 Color blue
@@ -659,62 +543,35 @@ Color blue blue
 >>> 1.0
 ]]]
 
-!!!!Metaclass creation.
-You define a class by filling in the template proposed on the instance side.
-When you compile this template, the system creates not just the class that you
-defined, but also the corresponding metaclass (which you can then edit by
-clicking on the ""Class side"" button).
-The only part of the metaclass creation template that makes sense for you to edit directly is the list of the metaclass's instance variable names.
+!!!!Metaclass creation
+
+You define a class by filling in the template proposed on the instance side. When you compile this template, the system creates not just the class that you defined, but also the corresponding metaclass (which you can then edit by clicking on the ""Class side"" button). The only part of the metaclass creation template that makes sense for you to edit directly is the list of the metaclass's instance variable names.
 
 Once a class has been created, browsing its instance side lets you edit and browse the methods that will be possessed by instances of that class (and of its subclasses).
 
 !!!Class methods
-Class methods can be quite useful, you can browse ==Color class== for some good examples: 
-You will see that there are two kinds of methods defined on a class:
-''instance creation methods'', like the class method ==blue== in the class ==Color class==, and those that
-perform a utility function, like ==Color class>>wheel:==.
-This is typical, although you will occasionally find class methods used in other ways.
 
-It is convenient to place utility methods on the class side because they can be
-executed without having to create any additional objects first. Indeed, many of
-them will contain a comment designed to make it easy to execute them.
+Class methods can be quite useful, you can browse ==Color class== for some good examples: You will see that there are two kinds of methods defined on a class: ''instance creation methods'', like the class method ==blue== in the class ==Color class==, and those that perform a utility function, like ==Color class>>wheel:==. This is typical, although you will occasionally find class methods used in other ways.
 
-Browse method ==Color class>>wheel:==, double-click just at the beginning of the
-comment =="(Color wheel: 12) inspect"== and press ==CMD-d==. You will see the
-effect of executing this method.
+It is convenient to place utility methods on the class side because they can be executed without having to create any additional objects first. Indeed, many of them will contain a comment designed to make it easy to execute them.
 
-For those familiar with Java and C\+\+, class methods may seem similar to static
-methods. 
-However, the uniformity of the Pharo object model (where classes are
-just regular objects) means that they are somewhat different: Whereas Java
-static methods are really just statically-resolved procedures, Pharo class
-methods are dynamically-dispatched methods. 
-This means that inheritance, overriding and super-sends work for class methods in Pharo, whereas they don't work for static methods in Java.
+Browse method ==Color class>>wheel:==, double-click just at the beginning of the comment =="(Color wheel: 12) inspect"== and press ==CMD-d==. You will see the effect of executing this method.
 
-!!!Class instance variables
+For those familiar with Java and C\+\+, class methods may seem similar to static methods. However, the uniformity of the Pharo object model (where classes are just regular objects) means that they are somewhat different: Whereas Java static methods are really just statically-resolved procedures, Pharo class methods are dynamically-dispatched methods. This means that inheritance, overriding and super-sends work for class methods in Pharo, whereas they don't work for static methods in Java.
 
-With ordinary ''instance'' variables, all the instances of a class have the same set
-of variables (though each instance has its own private set of values), and
-the instances of its subclasses inherit those variables.
+!!! Class instance variables
 
-The story is exactly the same with ''class'' instance variables: a class is an object instance of another class.
-Therefore the class instance variables are defined on such classes and each class has its own private values for the class instance variables.
+With ordinary ''instance'' variables, all the instances of a class have the same set of variables (though each instance has its own private set of values), and the instances of its subclasses inherit those variables.
 
-Instance variables also works. Class instance variables are inherited:
-A subclass will inherit those class instance variables, ''but a subclass will have its own private copies of those variables''. 
-Just as objects don't share instance variables, neither do classes and their subclasses share class instance variables.
+The story is exactly the same with ''class'' instance variables: a class is an object instance of another class. Therefore the class instance variables are defined on such classes and each class has its own private values for the class instance variables.
 
-For example, you could use a class instance variable called ==count== to keep track of how many instances you create of a given class. 
-However, any subclass would have its own ==count== variable, so subclass instances would be counted
-separately.
-The following section presents an example. 
+Instance variables also works. Class instance variables are inherited: A subclass will inherit those class instance variables, ''but a subclass will have its own private copies of those variables''. Just as objects don't share instance variables, neither do classes and their subclasses share class instance variables.
+
+For example, you could use a class instance variable called ==count== to keep track of how many instances you create of a given class. However, any subclass would have its own ==count== variable, so subclass instances would be counted separately. The following section presents an example. 
 
 !!!Example: Class instance variables and subclasses
 
-Suppose we define the class ==Dog==, and its subclass ==Hyena==. Suppose that we
-add a ==count== class instance variable to the class ==Dog== (i.e., we define it
-on the metaclass ==Dog class==). ==Hyena== will naturally inherit the class
-instance variable ==count== from ==Dog==.
+Suppose we define the class ==Dog==, and its subclass ==Hyena==. Suppose that we add a ==count== class instance variable to the class ==Dog== (i.e., we define it on the metaclass ==Dog class==). ==Hyena== will naturally inherit the class instance variable ==count== from ==Dog==.
 
 [[[caption=Dog class definition.
 Object subclass: #Dog
@@ -735,8 +592,7 @@ Dog subclass: #Hyena
     package: 'Example'
 ]]]
 
-Now suppose we define class methods for ==Dog== to initialize its ==count== to
-==0==, and to increment it when new instances are created:
+Now suppose we define class methods for ==Dog== to initialize its ==count== to ==0==, and to increment it when new instances are created:
 
 [[[caption=Initialize the count of dogs.|label=scr:dogCount
 Dog class >> initialize
@@ -753,16 +609,14 @@ Dog class >> count
     ^ count
 ]]]
 
-Now when we create a new ==Dog==, the ==count== value of the class ==Dog== is
-incremented, and so is that of the class ==Hyena== (but the hyenas are counted
-separately).
+Now when we create a new ==Dog==, the ==count== value of the class ==Dog== is incremented, and so is that of the class ==Hyena== (but the hyenas are counted separately).
 
-!!!!About class ==initialize==. 
+!!!!About class ==initialize== 
+
 When you instantiate an object such as ==Dog new==, ==initialize== is called automatically as part of the ==new== message send (you can see for yourself by browsing the method ==new== in the class ==Behavior==). 
-But with classes, simply defining them does not automatically call ==initialize== because it is not clear to the system if a class is fully working.
-So we have to call ==initialize== explicitly here.
-By default class ==initialize== methods are automatically executed only when classes are loaded.
-See also the discussion about lazy initialization, below.
+But with classes, simply defining them does not automatically call ==initialize== because it is not clear to the system if a class is fully working. So we have to call ==initialize== explicitly here.
+
+By default class ==initialize== methods are automatically executed only when classes are loaded. See also the discussion about lazy initialization, below.
 
 [[[example=true|label=scr:dogCount2
 Dog initialize.
@@ -790,41 +644,22 @@ Hyena count
 
 !!! Stepping back
 
-Class instance variables are private to a class in exactly the same way that
-instance variables are private to an instance. Since classes and their
-instances are different objects, this has the following consequences:
+Class instance variables are private to a class in exactly the same way that instance variables are private to an instance. Since classes and their instances are different objects, this has the following consequences:
 
-""1."" A class does not have access to the instance variables of its own
-instances. So, the class ==Color== does not have access to the variables of an
-object instantiated from it, ==aColorRed==. In other words, just because a class
-was used to create an instance (using ==new== or a helper instance creation
-method like ==Color red==), it doesn't give ''the class'' any special direct
-access to that instance's variables. The class instead has to go through the
-accessor methods (a public interface) just like any other object.
+""1."" A class does not have access to the instance variables of its own instances. So, the class ==Color== does not have access to the variables of an object instantiated from it, ==aColorRed==. In other words, just because a class was used to create an instance (using ==new== or a helper instance creation method like ==Color red==), it doesn't give ''the class'' any special direct access to that instance's variables. The class instead has to go through the accessor methods (a public interface) just like any other object.
 
-""2."" The reverse is also true: an ''instance'' of a class does not have access
-to the class instance variables of its class. In our example above, ==aDog==
-(an individual instance) does not have direct access to the ==count== variable
-of the ==Dog== class (except, again, through an accessor method).
+""2."" The reverse is also true: an ''instance'' of a class does not have access to the class instance variables of its class. In our example above, ==aDog== (an individual instance) does not have direct access to the ==count== variable of the ==Dog== class (except, again, through an accessor method).
 
 @@important A class does not have access to the instance variables of its own instances. An instance of a class does not have access to the class instance variables of its class.
 
-For this reason, instance initialization methods must always be defined on the
-instance side, the class side has no access to instance variables, and so cannot
-initialize them! All that the class can do is to send initialization messages,
-using accessors, to newly created instances.
+For this reason, instance initialization methods must always be defined on the instance side, the class side has no access to instance variables, and so cannot initialize them! All that the class can do is to send initialization messages, using accessors, to newly created instances.
 
-Java has nothing equivalent to class instance variables. Java and C++ static
-variables are more like Pharo class variables (discussed in
-Section *@sec:classVars*), since in those languages all of the subclasses and
+Java has nothing equivalent to class instance variables. Java and C++ static variables are more like Pharo class variables (discussed in Section *@sec:classVars*), since in those languages all of the subclasses and
 all of their instances share the same static variable.
 
 !!!Example: Defining a Singleton
 
-Singleton is the most misunderstood design pattern. 
-When wrongly applied, it favors procedural style promoting single global access.
-However, the Singleton pattern provides a typical example of the use of class instance
-variables and class methods.
+Singleton is the most misunderstood design pattern. When wrongly applied, it favors procedural style promoting single global access. However, the Singleton pattern provides a typical example of the use of class instance variables and class methods.
 
 Imagine that we would like to implement a class ==WebServer==, and to use the Singleton pattern to ensure that it has only one instance.
 
@@ -837,18 +672,14 @@ Object subclass: #WebServer
     package: 'Web'
 ]]]
 
-Then, clicking on the ""Class side"" button, we add the (class) instance
-variable ==uniqueInstance==.
+Then, clicking on the ""Class side"" button, we add the (class) instance variable ==uniqueInstance==.
 
 [[[
 WebServer class
     instanceVariableNames: 'uniqueInstance'
 ]]]
 
-As a result, the class ==WebServer class== will have a new instance variable (in
-addition to the variables that it inherits from ==Behavior==, such as
-==superclass== and ==methodDict==). 
-It means that the value of this extra instance variable will describe the instance of the class ==WebServer class== i.e., the class ==WebServer==.
+As a result, the class ==WebServer class== will have a new instance variable (in addition to the variables that it inherits from ==Behavior==, such as ==superclass== and ==methodDict==). It means that the value of this extra instance variable will describe the instance of the class ==WebServer class== i.e., the class ==WebServer==.
 
 [[[example=true
 Point class allInstVarNames
@@ -860,11 +691,7 @@ WebServer class allInstVarNames
 >>>  "#(#superclass #methodDict #format #layout #organization #subclasses #name #classPool #sharedPools #environment #category #uniqueInstance)"
 ]]]
 
-We can now define a class method named ==uniqueInstance==, as shown below. This
-method first checks whether ==uniqueInstance== has been initialized. If it has
-not, the method creates an instance and assigns it to the class instance
-variable ==uniqueInstance==. 
-Finally the value of ==uniqueInstance== is returned. 
+We can now define a class method named ==uniqueInstance==, as shown below. This method first checks whether ==uniqueInstance== has been initialized. If it has not, the method creates an instance and assigns it to the class instance variable ==uniqueInstance==. Finally the value of ==uniqueInstance== is returned. 
 Since ==uniqueInstance== is a class instance variable, this method can directly access it.
 
 [[[language=smalltalk|label=scr:uniqueInstance|caption=Class-side accessor method ==uniqueInstance==.
@@ -873,69 +700,41 @@ WebServer class >> uniqueInstance
      ^ uniqueInstance
 ]]]
 
-The first time that ==WebServer uniqueInstance== is executed, an instance of the
-class ==WebServer== will be created and assigned to the ==uniqueInstance==
-variable. The next time, the previously created instance will be returned
-instead of creating a new one. (This pattern, checking if a variable is nil
-in an accessor method, and initializing its value if it is nil, is called
-''lazy initialization'').
+The first time that ==WebServer uniqueInstance== is executed, an instance of the class ==WebServer== will be created and assigned to the ==uniqueInstance== variable. The next time, the previously created instance will be returned instead of creating a new one. (This pattern, checking if a variable is nil in an accessor method, and initializing its value if it is nil, is called ''lazy initialization'').
 
-Note that the instance creation code in the code above.
-Script *@scr:uniqueInstance*
-is written as ==self new== and not as ==WebServer new==. 
-What is the difference?
-Since the ==uniqueInstance== method is defined in ==WebServer class==, you might
-think that there is no difference. 
-And indeed, until someone creates a subclass of ==WebServer==, they are the same. 
-But suppose that ==ReliableWebServer== is a subclass of ==WebServer==, and inherits the ==uniqueInstance== method. 
-We would clearly expect ==ReliableWebServer uniqueInstance== to answer a
-==ReliableWebServer==. 
-Using ==self== ensures that this will happen, since ==self== will be bound to the respective receiver, here the classes ==WebServer== and ==ReliableWebServer==. 
-Note also that ==WebServer== and ==ReliableWebServer== will each have a different value for their
-==uniqueInstance== instance variable.
+Note that the instance creation code in the code above. Script *@scr:uniqueInstance* is written as ==self new== and not as ==WebServer new==. What is the difference? Since the ==uniqueInstance== method is defined in ==WebServer class==, you might think that there is no difference. And indeed, until someone creates a subclass of ==WebServer==, they are the same. But suppose that ==ReliableWebServer== is a subclass of ==WebServer==, and inherits the ==uniqueInstance== method. We would clearly expect ==ReliableWebServer uniqueInstance== to answer a ==ReliableWebServer==.
+
+Using ==self== ensures that this will happen, since ==self== will be bound to the respective receiver, here the classes ==WebServer== and ==ReliableWebServer==. Note also that ==WebServer== and ==ReliableWebServer== will each have a different value for their ==uniqueInstance== instance variable.
 
 !!!A note on lazy initialization
 
 The setting of initial values for instances of objects generally belongs in the ==initialize== method.
-Putting initialization calls only in ==initialize== helps from a readability
-perspective \-\- you don't have to hunt through all the accessor methods to see
-what the initial values are. Although it may be tempting to instead initialize
-instance variables in their respective accessor methods (using ==ifNil:==
+Putting initialization calls only in ==initialize== helps from a readability perspective \-\- you don't have to hunt through all the accessor methods to see what the initial values are. Although it may be tempting to instead initialize instance variables in their respective accessor methods (using ==ifNil:==
 checks), avoid this unless you have a good reason.
 
 ''Do not over-use the lazy initialization pattern.''
 
-For example, in our ==uniqueInstance== method above, we used lazy initialization
-because users won't typically expect to call ==WebServer initialize==. Instead,
-they expect the class to be "ready" to return new unique instances. Because of
-this, lazy initialization makes sense. Similarly, if a variable is expensive to
-initialize (opening a database connection or a network socket, for example),
-you will sometimes choose to delay that initialization until you actually need
+For example, in our ==uniqueInstance== method above, we used lazy initialization because users won't typically expect to call ==WebServer initialize==. Instead, they expect the class to be "ready" to return new unique instances. Because of this, lazy initialization makes sense. Similarly, if a variable is expensive to initialize (opening a database connection or a network socket, for example), you will sometimes choose to delay that initialization until you actually need
 it.
 
 !!!Shared variables
-Now we will look at an aspect of Pharo that is not so easily covered by our five
-rules: shared variables.
+
+Now we will look at an aspect of Pharo that is not so easily covered by our five rules: shared variables.
 
 Pharo provides three kinds of shared variables:
 
 ""1."" ''Globally'' shared variables.
 
-""2."" ''Class variables'': variables shared between instances and classes. (Not
-to be confused with class instance variables, discussed earlier).
+""2."" ''Class variables'': variables shared between instances and classes. (Not to be confused with class instance variables, discussed earlier).
 
 ""3."" ''Pool variables'': variables shared amongst a group of classes,
 
-The names of all of these shared variables start with a capital letter, to warn
-us that they are indeed shared between multiple objects.
+The names of all of these shared variables start with a capital letter, to warn us that they are indeed shared between multiple objects.
 
 !!!!Global variables
 
-In Pharo, all global variables are stored in a namespace called ==Smalltalk globals==,
-which is implemented as an instance of the class ==SystemDictionary==.
-Global variables are accessible everywhere. 
-Every class is named by a global variable.
-In addition, a few globals are used to name special or commonly useful objects.
+In Pharo, all global variables are stored in a namespace called ==Smalltalk globals==, which is implemented as an instance of the class ==SystemDictionary==. Global variables are accessible everywhere. 
+Every class is named by a global variable. In addition, a few globals are used to name special or commonly useful objects.
 
 The variable ==Processor== names an instance of ==ProcessScheduler==, the main process scheduler of Pharo.
 
@@ -946,11 +745,7 @@ Processor class
 
 !!!!Other useful global variables
 
-""==Smalltalk=="" is the instance of ==SmalltalkImage==.
-It contains many functionality to manage the system. 
-In particular it holds a reference to the main namespace ==Smalltalk globals==. 
-This namespace includes ==Smalltalk== itself since it is a global variable.
-The keys to this namespace are the symbols that name the global objects in Pharo code. So, for example:
+""==Smalltalk=="" is the instance of ==SmalltalkImage==. It contains many functionality to manage the system. In particular it holds a reference to the main namespace ==Smalltalk globals==. This namespace includes ==Smalltalk== itself since it is a global variable. The keys to this namespace are the symbols that name the global objects in Pharo code. So, for example:
 
 [[[testcase=true
 Smalltalk globals at: #Boolean
@@ -1029,10 +824,7 @@ Object subclass: #Color
 	package: 'Colors-Base'
 ]]]
 
-The class variable ==ColorRegistry== is an instance of ==IdentityDictionary==
-containing the frequently-used colors, referenced by name. 
-This dictionary is shared by all the instances of ==Color==, as well as the class itself.
-It is accessible from all the instance and class methods.
+The class variable ==ColorRegistry== is an instance of ==IdentityDictionary== containing the frequently-used colors, referenced by name. This dictionary is shared by all the instances of ==Color==, as well as the class itself. It is accessible from all the instance and class methods.
 
 % ==ColorNames== is initialized once in ==Color class>>initializeNames==, but it is accessed from instances of ==Color==.
 % The method ==Color>>name== uses the variable to find the name of a color.
@@ -1064,12 +856,8 @@ Color class >> initialize
     ...
 ]]]
 
-If you adopt this solution, you will need to remember to invoke the
-==initialize== method after you define it (by evaluating ==Color initialize==).
-Although class side ==initialize== methods are executed automatically when code
-is loaded into memory (from a Monticello repository, for example), they are
-''not'' executed automatically when they are first typed into the browser and
-compiled, or when they are edited and re-compiled.
+If you adopt this solution, you will need to remember to invoke the ==initialize== method after you define it (by evaluating ==Color initialize==). Although class side ==initialize== methods are executed automatically when code is loaded into memory (from a Monticello repository, for example), they are
+''not'' executed automatically when they are first typed into the browser and compiled, or when they are edited and re-compiled.
 
 !!!Pool variables
 
@@ -1079,8 +867,7 @@ Our advice is to avoid them; you will need them only in rare and specific circum
 Our goal here is therefore to explain pool variables just enough so that you can understand them when you are reading code.
 
 A class that accesses a pool variable must mention the pool in its class definition. 
-For example, the class ==Text== indicates that it is using the pool ==TextConstants==, which contains all the text constants such as ==CR== and ==LF==. 
-==TextConstants== defines the variables ==CR== that is bound to the value ==Character cr==, i.e., the carriage return character.
+For example, the class ==Text== indicates that it is using the pool ==TextConstants==, which contains all the text constants such as ==CR== and ==LF==. ==TextConstants== defines the variables ==CR== that is bound to the value ==Character cr==, i.e., the carriage return character.
 
 [[[label=scr:textPoolDict|caption=Pool dictionaries in the ==Text== class.
 ArrayedCollection subclass: #Text
@@ -1090,10 +877,7 @@ ArrayedCollection subclass: #Text
         package: 'Collections-Text'
 ]]]
 
-This allows methods of the class ==Text== to access the variables of the shared pool in the method body ''directly''.
-For example, we can write the following method. 
-We see that eventhough ==Text== does not define a variable ==CR==, since it declared that it uses the shared pool
-==TextConstants==, it can directly access it. 
+This allows methods of the class ==Text== to access the variables of the shared pool in the method body ''directly''. For example, we can write the following method. We see that eventhough ==Text== does not define a variable ==CR==, since it declared that it uses the shared pool ==TextConstants==, it can directly access it. 
 
 [[[label=scr:textTestCR|caption===Text>>testCR==.
 Text >> testCR
@@ -1121,11 +905,9 @@ SharedPool subclass: #TextConstants
 Once again, we recommend that you avoid the use of pool variables and pool
 dictionaries.
 
-
-
 !!! Abstract methods and abstract classes
 
-An abstract class is a class that exists to be subclassed, rather than to be
+An abstract class is a class that exists to be subclassed, rather than to be 
 instantiated. An abstract class is usually incomplete, in the sense that it does
 not define all of the methods that it uses. The "placeholder" methods, those
 that the other methods assume to be (re)defined are called abstract methods.
@@ -1172,14 +954,9 @@ Magnitude >> >= aMagnitude
 The same is true of the other comparison methods (they are all defined in terms
 of the abstract method ==<==).
 
-==Character== is a subclass of ==Magnitude==; it overrides the
-==<== method (which, if you recall, is marked as abstract in ==Magnitude== by
-the use of ==self subclassResponsibility==) with its own version (see the
-method definition below).
-%Script *@scr:characterLessThan*).
-==Character== also explicitly defines methods
-===== and ==hash==; it inherits from ==Magnitude== the methods ==>===, ==<===,
-==~=== and others.
+==Character== is a subclass of ==Magnitude==; it overrides the ==<== method (which, if you recall, is marked as abstract in ==Magnitude== by the use of ==self subclassResponsibility==) with its own version (see the
+method definition below). %Script *@scr:characterLessThan*). ==Character== also explicitly defines methods
+===== and ==hash==; it inherits from ==Magnitude== the methods ==>===, ==<===, ==~=== and others.
 
 [[[label=scr:characterLessThan|caption===Character>> <===.
 Character >> < aCharacter
@@ -1188,11 +965,9 @@ Character >> < aCharacter
     ^self asciiValue < aCharacter asciiValue
 ]]]
 
-
 !!!Chapter summary
 
-The object model of Pharo is both simple and uniform.
-Everything is an object, and pretty much everything happens by sending messages.
+The object model of Pharo is both simple and uniform. Everything is an object, and pretty much everything happens by sending messages.
 
 -Everything is an object. Primitive entities like integers are objects, but also classes are first-class objects.
 -Every object is an instance of a class. Classes define the structure of their instances via ''private'' instance variables and the behaviour of their instances via ''public'' methods. Each class is the unique instance of its metaclass. Class variables are private variables shared by the class and all the instances of the class. Classes cannot directly access instance variables of their instances, and instances cannot access instance variables of their class. Accessors must be defined if this is needed.

--- a/Chapters/PharoTour/Extracted.pillar
+++ b/Chapters/PharoTour/Extracted.pillar
@@ -2,11 +2,11 @@
 
 Pharoers ''love'' Test-Driven Development (TDD). TDD was discovered, or possibly reinvented, by Kent Beck and Ward Cunningham while they were working in Smalltalk, the language from which Pharo grew out. It is this heritage that makes TDD popular among the Pharo community, and also makes Pharo a great language to learn about TDD.
 
-The idea behind TDD is that we describe the desired behavior of our program in an automated test ''before'' we write any code; we write a ''failing test first''. Then we write code until the test passes, because when the test passes we know that we've achieved the behavior we want. 
+The idea behind TDD is that we describe the desired behavior of our program in an automated test ''before'' we write any code; we write a ''failing test first''. Then we write code until the test passes, because when the test passes, we know that we've achieved the behavior we wanted. 
 
-Suppose that our assignment is to write a method that "says something loudly and with emphasis". What exactly does that mean? What would be a good name for such a method? How can we make sure that the programmers  maintain our method in the future (including ourselves) have an unambiguous description of what the method should do? We can answer all of these questions by writing an example of our method being used.
+Suppose that our assignment is to write a method that "says something loudly and with emphasis". What exactly does that mean? What would be a good name for such a method? How can we make sure that the programmers maintaining our method in the future (including ourselves) have an unambiguous description of what the method should do? We can answer all of these questions by writing an example of our method being used.
 
-Our goal is to define a new method named ==shout== in the class ==String==. The idea is that this message should turn a string into its uppercase version as shown in the example below:
+Our goal is to define a new method named ==shout== in the class ==String==. The idea is that this message should turn a string into its uppercase version, as shown in the example below:
 
 [[[testcase=true
 'No panic' shout
@@ -28,7 +28,7 @@ testShout
 	self assert: ('No panic' shout = 'NO PANIC!')
 ]]]
 
-==self== refers to the object the method is defined in, and the ==assert:== method is the test class's way of running a test. It says 'the following expression must be true'. And so we're saying '==No panic' shout== is equal to =='NO PANIC'=='
+==self== refers to the object the method is defined on, and the ==assert:== method is the test class's way of running a test. It says, 'the following expression must be true'. And so we're saying '==No panic' shout== is equal to =='NO PANIC'=='
 
 Once you have typed the text into the browser, notice that the right upper corner is orange. This is a reminder that the pane contains changes that have not been 'saved', which really means that they have not been compiled as part of the class. So, select ""Accept"" by right clicking in the bottom pane, or just hit ==Cmd-S==, to compile and save your method. You should see a situation similar to the one depicted in Figure *@fig:testshout*.
 
@@ -61,11 +61,11 @@ If you click on that method in the bottom right pane, the erroneous test will ru
 The window that opens with the error message is the Pharo debugger. We will look at the debugger in detail and learn how to use it in Chapter:
 *The Pharo Environment>../Environment/Environment.pillar@cha:env*.
 
-+Pressing the Create button in the debugger prompts you to select in which class to create the new method.>file://figures/preview-2.png|width=50|label=fig:createPromptWhichClass+
++Pressing the Create button in the debugger prompts you to select the class to create the new method.>file://figures/preview-2.png|width=50|label=fig:createPromptWhichClass+
 
 !!!Implementing the Tested Method
 
-The error is, of course, exactly what we expected: running the test generates an error because we have not yet written a method that tells strings how to shout. Nevertheless, it's ''absolutely best practice'' to run the test and to make sure that it fails. This confirms that we have set up the testing machinery correctly and that the new test is actually being run; you need to know the rubber is hitting the road, so to speak. Once you have seen the error, you can ""Abandon"" the running test, which will close the debugger window.
+The error is, of course, exactly what we expected: running the test generates an error because we have not yet written a method that tells strings how to shout. Nevertheless, it's ''absolutely best practice'' to run the test and to make sure that it fails. This confirms that we have set up the testing machinery correctly and that the new test is actually being run; you need to know that the rubber is hitting the road, so to speak. Once you have seen the error, you can ""Abandon"" the running test, which will close the debugger window.
 
 +The automatically created ==shout== method waiting for a real definition.>file://figures/shoutInDebugger-4.png|width=70|label=fig:shoutShouldBeImplemented+
 
@@ -73,9 +73,9 @@ But what if we didn't close the debugger...?
 
 !!!!Coding in the Debugger
 
-Instead of pressing ""Abandon"", you can define the missing method using the ""Create"" button, right in the debugger itself. This will prompt you to select a class in which to define the new method (see Figure *@fig:createPromptWhichClass*), then prompt you to select a protocol for that method, and then finally take you to a code editor window in the debugger, in which you can edit the code for this newly created method. Note that since the system cannot implement the method for you, it creates a generic method that is 'tagged' as to be implemented (see Figure *@fig:shoutShouldBeImplemented*).
+Instead of pressing ""Abandon"", you can define the missing method using the ""Create"" button, right in the debugger itself. This will prompt you to select a class in which to define the new method (see Figure *@fig:createPromptWhichClass*), then prompt you to select a protocol for that method, and finally take you to a code editor window in the debugger, in which you can edit the code for this newly created method. Note that since the system cannot implement the method for you, it creates a generic method that is 'tagged' as to be implemented (see Figure *@fig:shoutShouldBeImplemented*).
 
-Now let's define the method that will make the test pass! Right inside the debugger edit the ==shout== method with this definition (as shown in Figure *@fig:shoutInDBG*):
+Now let's define the method that will make the test pass! Right inside the debugger, edit the ==shout== method with this definition (as shown in Figure *@fig:shoutInDBG*):
 
 [[[
 shout

--- a/Chapters/PharoTour/Finding.pillar
+++ b/Chapters/PharoTour/Finding.pillar
@@ -97,7 +97,6 @@ You can also use the Finder to search for methods with one or more arguments. Fo
 
 So far, we've seen a lot of tools that are useful when we're trying to ''find'' something in Pharo. Now let's take a look at some other other tools in Pharo, while we write a new method through the technique of ''Test-Driven Development''.
 
-
 !!! Conclusion
 
 - The ""Spotter"" is a powerful tool to navigate the system and find information.

--- a/Chapters/PharoTour/GettingStarted.pillar
+++ b/Chapters/PharoTour/GettingStarted.pillar
@@ -1,10 +1,8 @@
 !!Getting Started with  Pharo
 @cha:getting
 
-
 In this chapter, you will learn how to start Pharo and the different files that make up a Pharo system and the roles they perform, learn about the different ways of interacting with the system, and discover some of the basic tools. You will also learn how to define a new method, create an object, and send it messages.
 The chapter shows (1) how to install Pharo and (2) how to launch Pharo.
-
 
 !!! Installing Pharo
 
@@ -13,7 +11,6 @@ Pharo does not need to install anything in your system, as it's perfectly capabl
 !!!! The Pharo Launcher
 
 Pharo Launcher is a cross-platform application that facilitates the management of multiple Pharo images and VMs. It is available as a free download from *http://pharo.org/download>http://pharo.org/download*.  Click the button for your operating system to download the appropriate Pharo Launcher; it contains everything you need to run Pharo.
-
 
 !!!! Zeroconf scripts
 
@@ -144,8 +141,6 @@ When you save your image the ==.image== file is updated with the snapshot of you
 
 It may seem like the image file should be the key mechanism for storing and managing software projects, but in practice that is not the case at all. There are much better tools for managing code and sharing software that is developed in a team. Images are useful, but you should be very cavalier about creating and throwing away images. Versioning tools such as Iceberg offer us a much better way to manage and share code. In addition, if you need to persist objects, you can use a package such as Fuel (a fast object binary serializer) or STON (a textual object serializer), or even use a database.
 
-
-
 !!!For the fast and furious
 
 Sometimes reading long chapters about a system that's as full of features as Pharo can be, well, ''boring''. If you've already got a working Pharo system installed on your computer, and you know a little bit about how everything works, you might want learn the basics by using ProfStef and then skip forward to the next chapter: a tutorial to define a simple counter and its associated tests. You can also watch the corresponding video available at *http://mooc.pharo.org*. 
@@ -167,7 +162,6 @@ This expression will trigger the ""ProfStef"" tutorial (as shown in Figure *@fig
 Congratulations! You have just sent your first message! Pharo is based on the concept of sending messages to objects. The Pharo objects are like your soldiers, just waiting for you to send them a message they can understand. We will see exactly how an object understands a message later on.
 
 +ProfStef is a simple interactive tutorial to learn about Pharo syntax.>file://figures/ProfStef.png|width=60|label=fig:ProfStef+
-
 
 !!!Chapter summary
 

--- a/Chapters/PharoTour/PharoTour.pillar
+++ b/Chapters/PharoTour/PharoTour.pillar
@@ -13,17 +13,15 @@ Try to remember that this is a ''quick'' tour of Pharo, a taster of the environm
 
 Once Pharo is running, you should see a single large window, possibly containing some open playground windows (see Figure *@fig:worldMenu*). You might notice a menu bar, but Pharo also makes use of context-dependent pop-up menus.
 
-pharotutorial
+Clicking anywhere on the background of the Pharo window will display the ""World Menu"", which contains many of the Pharo tools, utilities, and settings.
 
-Clicking anywhere on the background of the Pharo window will display the ""World Menu"", which contains many of the Pharo tools, utilities and settings.
-
-Take a minute to explore the World Menu. You will will see a list containing many of Pharo's core tools, including the System Browser, the Playground, the package manager Iceberg, and many others. We will discuss them all in more detail in the coming chapters.
+Take a minute to explore the World Menu. You will see a list containing many of Pharo's core tools, including the System Browser, the Playground, the package manager Iceberg, and many others. We will discuss them all in more detail in the coming chapters.
 
 !!!Interacting with Pharo
 
 Pharo offers three ways to interact with the system using a mouse or other pointing device.
 
-""click"" (or left-click): this is the most often used mouse button, and is normally equivalent to left-clicking (or clicking a single mouse button without any modifier key). For example, click on the background of the Pharo window to bring up the World Menu (Figure *@fig:worldMenu*).
+""click"" (or left-click): this is the most commonly used mouse button, and is normally equivalent to left-clicking (or clicking a single mouse button without any modifier key). For example, click on the background of the Pharo window to bring up the World Menu (Figure *@fig:worldMenu*).
 
 ""action-click"" (or right-click): this is the next most used button. It is used to bring up a contextual menu that offers different sets of actions depending on where the mouse is pointing (see Figure *@fig:operating*). If you do not have a multi-button mouse, then normally you would configure action-click to be performed when clicking the mouse button and holding down the control modifier.
 
@@ -33,12 +31,11 @@ Pharo offers three ways to interact with the system using a mouse or other point
 
 +Meta-Clicking on a window opens the Halos.>file://figures/addHalo.png|width=70|label=fig:halos+
 
-
 !!!!About vocabulary
 
-If you talk to Pharoers for a while, you will notice that they generally do not use phrases like ''call an operation'' or ''invoke a method'', which you might hear in other programming languages. Instead they will say ''send a message''. This reflects the idea that objects are responsible for their own actions and that the method associated with the message is looked up dynamically. When sending a message to an object it is the object, and not the sender, that selects the appropriate method for responding to your message. In most (but not all) cases, the method with the same name as the message is executed.
+If you talk to Pharoers for a while, you will notice that they generally do not use phrases like ''call an operation'' or ''invoke a method'', which you might hear in other programming languages. Instead, they will say ''send a message''. This reflects the idea that objects are responsible for their own actions and that the method associated with the message is looked up dynamically. When sending a message to an object, it is the object, and not the sender, that selects the appropriate method for responding to your message. In most (but not all) cases, the method with the same name as the message is executed.
 
-As a user you do not need to understand how each message works, the only thing you need to know is what the available messages are for the objects that interest you. This way an object can hide its complexity, and coding can be kept as simple as possible without losing flexibility.
+As a user, you do not need to understand how each message works, the only thing you need to know is what the available messages are for the objects that interest you. This way, an object can hide its complexity, and coding can be kept as simple as possible without losing flexibility.
 
 How to find the available messages for each object is something we will explore later on.
 
@@ -50,9 +47,9 @@ Let's do some simple exercises to get comfortable in our new environment:
 # Look in the menu and open a Transcript and a Playground.
 # Position and resize the transcript and playground windows so that the Playground just overlaps the Transcript (see Figure *@fig:HelloWorld*).
 
-You can resize windows by dragging one of the corners. At any time only one window is active; it is in front and has its border highlighted.
+You can resize windows by dragging one of the corners. At any given time only one window is active; it is the one in front and has its border highlighted.
 
-!!!!About Playground
+!!!! About Playground
 
 A ""Playground"" is useful for typing and running snippets of code that you would like to experiment with. You can also use Playgrounds for typing ''any'' text that you would like to remember, such as to-do lists or instructions for anyone who will use your image.
 
@@ -62,7 +59,7 @@ Type the following text into the Playground:
 Transcript show: 'hello world'; cr.
 ]]]
 
-Try double-clicking at various points on the text you have just typed. Notice how an entire word, an entire line, or all of the text is selected, depending on whether you click within a word, at the end of a line, or at the end of the entire expression. In particular, if you place the cursor before the first character or after the last character and double-click, you select the complete paragraph.
+Try double-clicking at various points on the text you have just typed. Notice how an entire word, an entire line, or all of the text is selected, depending on whether you click within a word, at the end of a line, or at the end of the entire expression. In particular, if you place the cursor before the first character or after the last character and double-click, you select the entire paragraph.
 
 Select the text you have typed, right click and select ""Do it"". Notice how the text ==hello world== appears in the Transcript window (See Figure *@fig:HelloWorld*). Do it again!
 
@@ -70,9 +67,9 @@ Select the text you have typed, right click and select ""Do it"". Notice how the
 
 !!!Keyboard shortcuts
 
-If you want to evaluate an expression, you do not always have to right click. Instead, you can use the keyboard shortcuts that are shown next to each menu item. Even though Pharo may seem like a mouse driven environment, it contains over 200 shortcuts for all of its different tools, as well as the facility to assign a keyboard shortcut to ''any'' of the 110 000 methods contained in the Pharo image. 
+If you want to evaluate an expression, you do not always have to right click. Instead, you can use the keyboard shortcuts that are shown next to each menu item. Even though Pharo may seem like a mouse driven environment, it contains over 200 shortcuts for all of its different tools, as well as the facility to assign a keyboard shortcut to ''any'' of the 143 000 methods contained in the Pharo image. 
 
-Depending on your platform, you may have to press one of the modifier keys which are Control, Alt, and Command. We will use ==Cmd== in the rest of the book, so each time you see something like ==Cmd-D==, just replace it with the appropriate modifier key depending on your operating system. The corresponding modifier key in Windows is ==Ctrl==, and in Linux it is either ==Alt== or ==Ctrl==.
+Depending on your platform, you may have to press one of the modifier keys, which are Control, Alt, and Command. We will use ==Cmd== in the rest of the book, so each time you see something like ==Cmd-D==, just replace it with the appropriate modifier key depending on your operating system. The corresponding modifier key in Windows is ==Ctrl==, and in Linux it is either ==Alt== or ==Ctrl==.
 
 In addition to ""Do it"", you might have noticed ""Do it and go"", ""Print it"", ""Inspect it"" and several other options in the context menu. Let's have a quick look at each of these.
 
@@ -80,7 +77,7 @@ In addition to ""Do it"", you might have noticed ""Do it and go"", ""Print it"",
 
 Type the expression ==3 + 4== into the playground. Now ""Do it"" with the keyboard shortcut ==Cmd-D==.
 
-Do not be surprised if you saw nothing happen! What you just did is send the message ==\+== with argument ==4== to the number ==3==. Normally the resulting ==7== would have been computed and returned to you, but since the playground did not know what to do with this answer, it simply did not show the answer. If you want to see the result, you should ""Print it"" instead. ""Print it"" actually compiles the expression, executes it, then sends the message ==printString== to the result, and displays the resulting string.
+Don't be surprised if nothing happened! What you just did is send the message ==\+== with argument ==4== to the number ==3==. Normally, the resulting ==7== would have been computed and returned to you, but since the playground did not know what to do with this answer, it simply did not show the answer. If you want to see the result, you should ""Print it"" instead. ""Print it"" actually compiles the expression, executes it, sends the message ==printString== to the result, and displays the resulting string.
 
 Select ==3 + 4== and ""Print it"" (==Cmd-P==). This time we see the result we expect.
 
@@ -119,11 +116,11 @@ Other right-click options that may be used are the following:
 
 !!!Calypso: the System Browser
 
-The ""System Browser"", also known as "Class Browser", is one of the key tools used for programming in Pharo. As we shall see, there are actually several interesting browsers available in Pharo, but this is the basic one you will find in any image. The current implementation of the System Browser is called ""Calypso"". The previous version of the System Browser was called ""Nautilus"".
+The ""System Browser"", also known as the "Class Browser", is one of the key tools used for programming in Pharo. As we shall see, there are actually several interesting browsers available in Pharo, but this is the basic one you will find in any image. The current implementation of the System Browser is called ""Calypso"". The previous version of the System Browser was called ""Nautilus"".
 
 !!!!Opening the System Browser on a given method
 
-+The System Browser showing the ==slowFactorial== method of the class ==Integer==.>file://figures/system-browser-annotated.pdf|width=100|label=fig:systemBrowser+
++The System Browser shows the ==slowFactorial== method of the class ==Integer==.>file://figures/system-browser-annotated.pdf|width=100|label=fig:systemBrowser+
 
 This is not the usual way that we open a browser on a method: we can use much more advanced tools! But for the sake of this exercise, please execute the following code snippet:
 
@@ -131,22 +128,19 @@ This is not the usual way that we open a browser on a method: we can use much mo
 ClyFullBrowserMorph openOnMethod: Integer>>#slowFactorial
 ]]]
 
-It will open a System Browser on the method ==slowFactorial==, showing something like in Figure *@fig:systemBrowser*. The title bar of 'Integer>>#slowFactorial' indicates that we are browsing the class ==Integer== and its method ==slowFactorial==. Figure *@fig:systemBrowser* shows the different entities displayed by the browser: packages, classes, protocols, methods and the method definition.
+It will open a System Browser on the method ==slowFactorial==, showing something like in Figure *@fig:systemBrowser*. The title bar of 'Integer>>#slowFactorial' indicates that we are browsing the class ==Integer== and its method ==slowFactorial==. Figure *@fig:systemBrowser* shows the different entities displayed by the browser: packages, classes, protocols, methods, and the method definition.
 
 In Pharo, the default System Browser is Calypso. However, as we have mentioned, it is possible to have other System Browsers installed in the Pharo environment. Each System Browser may have its own GUI that may be very different from the Calypso GUI. From now on, we will use the terms 'Browser', 'System Browser' and 'Calypso' interchangeably.
 
 +The System Browser showing the ==printString== method of class ==Object==.>file://figures/browsingprintString.png|width=100|label=fig:systemBrowser2+
 
-
 !!!Chapter summary
 
 This chapter has been a whirlwind tour to introduce you to the Pharo environment and some of the major tools you will use to program in it. You have also seen a little of Pharo's syntax, even though you may not understand it all yet. Here's a little summary of what we've learned:
-
 
 - You can click on the Pharo background to bring up the ""World Menu"" and launch various tools.
 - A ""Playground"" is a tool for writing and evaluating snippets of code. You can also use it to store arbitrary text.
 - You can use keyboard shortcuts on text in the Playground, or any other tool, to evaluate code. The most important of these are ""Do it"" (==Cmd-D==), ""Print it"" (==Cmd-P==), ""Inspect it"" (==Cmd-I==), and ""Browse it"" (==Cmd-B==).
 - The ""System Browser"" is the main tool for browsing Pharo code and for developing new code.
-
 - The ""Test Runner"" is a tool for running unit tests, and aids in Test-Driven Development.
 - The ""Debugger"" allows you to examine errors and exceptions (such as errors or failures encountered when running tests). You can even create new methods right in the debugger.

--- a/Chapters/Preface/Preface.pillar
+++ b/Chapters/Preface/Preface.pillar
@@ -16,28 +16,28 @@ Many aspects of Pharo's tooling have changed since the last edition, and we have
 
 !!!What is Pharo?
 
-Pharo is a modern, open-source, dynamically-typed language which supports live coding and is inspired by Smalltalk. Pharo and its ecosystem is composed of six fundamental elements:
+Pharo is a modern, open-source, dynamically-typed language that supports live coding and is inspired by Smalltalk. Pharo and its ecosystem are composed of six fundamental elements:
 
 - A dynamically-typed language with a syntax so simple it can fit on a postcard, yet it can still be read by people who are unfamiliar with it.
 - A live coding environment that allows the programmer to seamlessly modify their code as it executes.
 - A powerful IDE providing tools to help manage complex code and promote good design.
 - A rich library that creates an environment so powerful that it can be viewed as a virtual OS, including a very fast JITing VM and full access to OS libraries and features via its FFI.
 - A culture where changes and improvements are encouraged and highly valued.
-- A community that welcomes coders from any corner of the world, of any skill or experience, in any programming language.
+- A community that welcomes coders from any corner of the world, of any skill level or experience, in any programming language.
 
-Pharo strives to offer a lean, open platform for professional software development, as well as a robust and stable platform for research and development into dynamic languages and environments. Pharo serves as the reference implementation for the Seaside web development framework available at *http://www.seaside.st*.
+Pharo strives to offer a lean, open platform for professional software development, as well as a robust and stable platform for research and development into dynamic languages and environments. Pharo serves as the reference implementation for the Seaside web development framework, available at *http://www.seaside.st*.
 
-Pharo's core contains only code that has been contributed under the MIT license. The Pharo project started in March 2008 as a fork of Squeak (a modern implementation of Smalltalk-80), and the first 1.0 beta version was released on July 31, 2009. Since then Pharo has reached a new version every year or year and a half. The current version is Pharo 9.0, released in July 2021.
+Pharo's core contains only code that has been contributed under the MIT license. The Pharo project started in March 2008 as a fork of Squeak (a modern implementation of Smalltalk-80), and the first 1.0 beta version was released on July 31, 2009. Since then, Pharo has reached a new version every year or year and a half. The current version is Pharo 9.0, released in July 2021.
 
 Pharo is highly portable. Pharo can run on OS X, Windows, Linux, Android, iOS, and Raspberry Pi. Its virtual machine is written entirely in a subset of Pharo, making it easy to simulate, debug, analyze, and change from within Pharo itself. Pharo is the vehicle for a wide range of innovative projects, from multimedia applications and educational platforms to commercial web development environments.
 
-There is an important principle behind Pharo: Pharo does not just copy the past, it ''reinvents'' the essence of Smalltalk. However we realize that Big Bang style approaches that start from scratch rarely succeed. Pharo instead favors evolutionary and incremental changes. Rather than leaping for the final perfect solution in one big step, a multitude of small changes keeps even the bleeding edge relatively stable while allowing us to experiment with important new features and libraries. This facilitates contributions and rapid feedback from the community, on which Pharo relies on for its success. Finally, Pharo is not read-only: changes from the community are integrated daily. Pharo has around 100 contributors, based all over the world. You can have an impact on Pharo too! Just take a look at *http://github.com/pharo-project/pharo*.
+There is an important principle behind Pharo: Pharo does not just copy the past, it ''reinvents'' the essence of Smalltalk. However, we realize that Big Bang style approaches that start from scratch rarely succeed. Pharo instead favors evolutionary and incremental changes. Rather than leaping for the perfect solution in one big step, a multitude of small changes keeps even the bleeding edge relatively stable while allowing us to experiment with important new features and libraries. This facilitates contributions and rapid feedback from the community, which Pharo relies on for its success. Finally, Pharo is not read-only: changes from the community are integrated daily. Pharo has around 100 contributors, based all over the world. You can have an impact on Pharo too! Just take a look at *http://github.com/pharo-project/pharo*.
 
 !!!Who should read this book?
 
-This book will not teach you how to program. The reader should have some familiarity with programming languages. Some background with object-oriented programming would also be helpful.
+This book will not teach you how to program. The reader should have some familiarity with programming languages. Some background in object-oriented programming would also be helpful.
 
-The current book will introduce the Pharo programming environment, the language and the associated tools. You will be exposed to common idioms and practices, but the focus is on the technology, not on object-oriented design. We will show you good, illustrative examples as often as possible.
+The current book will introduce the Pharo programming environment, the language, and the associated tools. You will be exposed to common idioms and practices, but the focus is on the technology, not on object-oriented design. We will show you good, illustrative examples as often as possible.
 
 !!!!The Pharo MOOC
 
@@ -67,7 +67,6 @@ In addition, there are numerous other books on Smalltalk freely available  at *h
 
 Do not be frustrated by parts of Pharo that you do not immediately understand: ''You do not have to know everything''. Alan Knight expresses this as follows:
 
-
 ""''Try not to care''.""  Beginning Pharo programmers often have trouble because they think they need to understand all the details of how a thing works before they can use it. This means it takes quite a while before they can master ==Transcript show: 'Hello World'==. One of the great leaps in OO [object-oriented programming] is to be able to answer the question "How does this work?" with "I don't care".
 
 When you do not understand something, simple or complex, do not hesitate to ask us on our mailing lists (pharo-users@lists.pharo.org or pharo-dev@lists.pharo.org), IRC and Discord. We love questions and we welcome people of any skill.
@@ -92,7 +91,6 @@ The Pharo community is friendly and active. Here is a short list of resources th
 - Pharoers started a wiki on Pharo: *https://github.com/pharo-open-documentation/pharo-wiki>https://github.com/pharo-open-documentation/pharo-wiki*
 - An Awesome catalog is maintained with projects: *https://github.com/pharo-open-documentation/awesome-pharo>https://github.com/pharo-open-documentation/awesome-pharo*
 - If you hear about SmalltalkHub, *http://www.smalltalkhub.com/>http://www.smalltalkhub.com/* was the equivalent of SourceForge/GitHub for Pharo projects for about 10 years. Many extra packages and projects for Pharo lived there. Now the community is mainly using git repositories such as GitHub, GitLab, and Bitbucket.
-
 
 !!!Examples and exercises
 
@@ -131,8 +129,6 @@ testIncludes
     self assert: (full includes: 6).
     self assert: (empty includes: 5) not
 ]]] 
-
-
 
 !!!Acknowledgments
 

--- a/Chapters/SyntaxNutshell/SyntaxNutshell.pillar
+++ b/Chapters/SyntaxNutshell/SyntaxNutshell.pillar
@@ -2,11 +2,9 @@
 @cha:syntax
 
 Pharo adopts a syntax very close to that of its ancestor, Smalltalk.
-The syntax is designed so that program text can be read aloud as though it were a kind of
-pidgin English.
-The following method of the class ==Week== shows an example of the syntax.
-It checks whether ==DayNames== already contains the argument, i.e., if this argument represents a correct day name. 
-If this is the case, it will assign it to the class variable ==StartDay==.
+
+The syntax is designed so that program text can be read aloud as though it were a kind of pidgin English.
+The following method of the class ==Week== shows an example of the syntax. It checks whether ==DayNames== already contains the argument, i.e., if this argument represents a correct day name. If this is the case, it will assign it to the class variable ==StartDay==.
 
 [[[
 startDay: aSymbol
@@ -16,13 +14,9 @@ startDay: aSymbol
       ifFalse: [ self error: aSymbol, ' is not a recognised day name' ]
 ]]]
 
-Pharo's syntax is minimal. Essentially there is syntax only for sending messages (i.e., expressions). 
-Expressions are built up from a very small number of primitive elements (message sends, assignments, closures, returns...).
-There are only 6 reserved keywords, i.e., pseudo-variables, and there are no dedicated syntax constructs for control structures or declaring new classes.
-Instead, nearly everything is achieved by sending messages to objects.
-For instance, instead of an if-then-else control structure, conditionals are
-expressed as messages (such as ==ifTrue:==) sent to Boolean objects.
-New subclasses are created by sending a message to their superclass.
+Pharo's syntax is minimal. Essentially there is syntax only for sending messages (i.e., expressions). Expressions are built up from a very small number of primitive elements (message sends, assignments, closures, returns...). There are only 6 reserved keywords, i.e., pseudo-variables, and there are no dedicated syntax constructs for control structures or declaring new classes. Instead, nearly everything is achieved by sending messages to objects. 
+
+For instance, instead of an if-then-else control structure, conditionals are expressed as messages (such as ==ifTrue:==) sent to Boolean objects. New subclasses are created by sending a message to their superclass.
 
 !!! Syntactic elements
 
@@ -35,7 +29,6 @@ Expressions are composed of the following building blocks:
 # Block closures
 # Messages
 # Method returns
-
 
 We can see examples of the various syntactic elements in the table below.
 
@@ -64,50 +57,23 @@ We can see examples of the various syntactic elements in the table below.
 |==x := 2 . x := x + x==| two expressions separated by separator (==.==)
 |==Transcript show: 'hello'; cr==| two cascade messages separated by  (==;==)
 
+""Local variables."" ==startPoint== is a variable name, or identifier. By convention, identifiers are composed of words in "camelCase" (i.e., each word except the first starting with an upper case letter). The first letter of an instance variable, method or block parameters, or temporary variable must be lower case. This indicates to the reader that the variable has a private scope.
 
+""Shared variables."" Identifiers that start with upper case letters are global variables, class variables, pool dictionaries or class names. ==Transcript== is a global variable, an instance of the class ==ThreadSafeTranscript==.
 
-""Local variables."" ==startPoint== is a variable name, or identifier. By
-convention, identifiers are composed of words in "camelCase" (i.e., each word
-except the first starting with an upper case letter). The first letter of an
-instance variable, method or block parameters, or temporary variable must be lower
-case. This indicates to the reader that the variable has a private scope.
+""The message receiver."" ==self== is a pseudo-variable that refers to the object that receives the message (that led to the execution of the method using ==self==). It gives us a way send messages to it. We call ==self== "the receiver" because this object will receive the message that causes the method to be executed. Finally, ==self== is called a "pseudo-variable" since we cannot directly change its values or assign to it.
 
-""Shared variables."" Identifiers that start with upper case letters are global
-variables, class variables, pool dictionaries or class names. ==Transcript== is
-a global variable, an instance of the class ==ThreadSafeTranscript==.
+""Integers."" In addition to ordinary decimal integers like 42, Pharo also provides a radix notation. ==2r101== is 101 in radix 2 (i.e., binary), which is equal to decimal 5.
 
-""The message receiver."" ==self== is a pseudo-variable that refers to the object that receives 
-the message (that led to the execution of the method using ==self==).
-It gives us a way send messages to it. We call ==self== "the receiver" because this object
-will receive the message that causes the method to be executed. Finally, ==self== is called a
-"pseudo-variable" since we cannot directly change its values or assign to it.
+""Floating point numbers."" Such numbers can be specified with their base-ten exponent: ==2.4e7== is ==2.4 x 10^7==.
 
-""Integers."" In addition to ordinary decimal integers like 42, Pharo also
-provides a radix notation. ==2r101== is 101 in radix 2 (i.e., binary), which is
-equal to decimal 5.
+""Characters."" A dollar sign introduces a literal character: ==$a== is the literal for the character =='a'==. Instances of special, non-printing characters can be obtained by sending appropriately named messages to the ==Character== class, such as ==Character space== and ==Character tab==.
 
-""Floating point numbers."" Such numbers can be specified with their base-ten exponent:
-==2.4e7== is ==2.4 x 10^7==.
+""Strings."" Single quotes ==' '== are used to define a literal string. If you want a string with a single quote inside, just double the quote, as in =='G'\'day'==.
 
-""Characters."" A dollar sign introduces a literal character: ==$a== is the
-literal for the character =='a'==. Instances of special, non-printing characters can be
-obtained by sending appropriately named messages to the ==Character== class,
-such as ==Character space== and ==Character tab==.
+""Symbols."" Symbols are like Strings, in that they contain a sequence of characters. However, unlike a string, a literal symbol is guaranteed to be globally unique. There is only one ==Symbol== object ==#Hello== but there may be multiple ==String== objects with the value =='Hello'==.
 
-""Strings."" Single quotes ==' '== are used to define a literal string. If you
-want a string with a single quote inside, just double the quote, as in
-=='G'\'day'==.
-
-""Symbols."" Symbols are like Strings, in that they contain a sequence of
-characters. However, unlike a string, a literal symbol is guaranteed to be
-globally unique. There is only one ==Symbol== object ==#Hello== but there may be
-multiple ==String== objects with the value =='Hello'==.
-
-""Compile-time literal arrays."" They are defined by ==#( )==, surrounding space-separated
-literals. Everything within the parentheses must be a compile-time constant. For
-example, ==#(27 (true) abc 1+2)== is a literal array of 6 elements: the
-integer 27, the compile-time array containing the object ==true== (non-changeable Boolean), the symbol
-==#abc==, the integer 1, the symbol ==\+== and the integer 2. Note that this is the same as ==#(27 #(true) #abc 1 #+ 2)==.
+""Compile-time literal arrays."" They are defined by ==#( )==, surrounding space-separated literals. Everything within the parentheses must be a compile-time constant. For example, ==#(27 (true) abc 1+2)== is a literal array of 6 elements: the integer 27, the compile-time array containing the object ==true== (non-changeable Boolean), the symbol ==#abc==, the integer 1, the symbol ==\+== and the integer 2. Note that this is the same as ==#(27 #(true) #abc 1 #+ 2)==.
 
 ""Run-time dynamic arrays."" Curly braces =={ }== define a dynamic array whose elements are expressions, separated by periods, and evaluated at run-time.
 So =={ 1. 2. 1 + 2 }== defines an array with elements 1, 2, and 3 the result of evaluating ==1+2==.
@@ -115,18 +81,13 @@ So =={ 1. 2. 1 + 2 }== defines an array with elements 1, 2, and 3 the result of 
 ""Comments."" They are enclosed in double quotes \" \". "hello" is a comment, not a
 string, and is ignored by the Pharo compiler. Comments may span multiple lines but they cannot be nested.
 
-""Local variable definitions."" Vertical bars ==| |== enclose the declaration of
-one or more local variables before the beginning of a method or a block body.
+""Local variable definitions."" Vertical bars ==| |== enclose the declaration of one or more local variables before the beginning of a method or a block body.
 
 ""Assignment."" The two characters ==:= == specify that a variable refers to an object.
 
-""Blocks."" Square brackets ==[ ]== define a block, also known as a block
-closure or a lexical closure, which is a first-class object representing a
-function. As we shall see, blocks may take arguments (==[:i | ...]==) and can
-have local variables (==[| x | ...]==). Blocks also close over their definition environment, i.e., they can refer to variables that where reachable at the time of their definition.
+""Blocks."" Square brackets ==[ ]== define a block, also known as a block closure or a lexical closure, which is a first-class object representing a function. As we shall see, blocks may take arguments (==[:i | ...]==) and can have local variables (==[| x | ...]==). Blocks also close over their definition environment, i.e., they can refer to variables that where reachable at the time of their definition.
 
-""Pragmas and primitives."" ==< primitive: ... >== is a method annotation. This specific one denotes the invocation of a virtual
-machine (VM) primitive. In the case of a primitive the code following it, it either to explain what the primitive is doing (for essential primitives) or is executed only if the primitive fails (for optional primitive). The same syntax of a message within ==< >== is also used for other kinds of method annotations also called pragmas.
+""Pragmas and primitives."" ==< primitive: ... >== is a method annotation. This specific one denotes the invocation of a virtual machine (VM) primitive. In the case of a primitive the code following it, it either to explain what the primitive is doing (for essential primitives) or is executed only if the primitive fails (for optional primitive). The same syntax of a message within ==< >== is also used for other kinds of method annotations also called pragmas.
 
 ""Unary messages."" These consist of a single word (like ==factorial==) sent to
 a receiver (like 3). In ==3 factorial==, 3 is the receiver, and ==factorial== is
@@ -184,6 +145,7 @@ Here we give a brief overview on message kinds and ways for sending and executin
 
 
 !!!!Message precedence
+
 Unary messages have the highest precedence, then binary messages, and finally keyword messages, while brackets can be used to change the evaluation order.
 
 Thus, in the following example we first send ==factorial== to 3 which will give us result 6. Afterwards we send ==\+ 6== to 1 which gives the result 7, and finally we send ==raisedTo: 7== to 2.


### PR DESCRIPTION
- This PR consist of fixes to grammar and addition of missing punctuation. None of the editions changed any meaning of explanations or structure/references.
- Also, most .pillar files contained unnecessary CR's in paragraphs, making it difficult and uncomfortable to edit/find text in a text editor.